### PR TITLE
feat(auth): OAuth credential producer, Kimi/MiniMax, and Windows lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ tool_struggles.txt
 #   .claude/settings.local.json is per-developer, ignore separately if needed
 # === End crosslink managed ===
 .claude/worktrees/
+
+# oh-my-claudecode — machine-local orchestration state (never commit)
+.omc/
+.aider*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "which",
+ "windows-sys 0.59.0",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["command-line-utilities", "development-tools"]
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"] }
+
 [dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/src/claude_credentials.rs
+++ b/src/claude_credentials.rs
@@ -84,14 +84,30 @@ pub struct LoadedCredentials {
     pub scopes: Vec<String>,
 }
 
-/// Get the path to Claude Code's credentials file
-fn credentials_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claude").join(".credentials.json"))
+/// Resolve Claude Code's config directory.
+///
+/// Honors `CLAUDE_CONFIG_DIR` (matching Claude Code and forks such as
+/// `@gitlawb/openclaude`) so multi-profile / container setups read and write
+/// the same location; falls back to `~/.claude`.
+fn claude_config_dir() -> Option<PathBuf> {
+    match std::env::var_os("CLAUDE_CONFIG_DIR") {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => dirs::home_dir().map(|h| h.join(".claude")),
+    }
+}
+
+/// Path to Claude Code's credentials file (`<config-dir>/.credentials.json`).
+///
+/// Public so callers (e.g. `openclaudia auth --status`) can show users where
+/// credentials live.
+#[must_use]
+pub fn credentials_path() -> Option<PathBuf> {
+    claude_config_dir().map(|d| d.join(".credentials.json"))
 }
 
 /// Path to the advisory lock file for credential access.
 fn lock_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claude").join(".credentials.lock"))
+    claude_config_dir().map(|d| d.join(".credentials.lock"))
 }
 
 /// Advisory file lock for credential access.
@@ -140,12 +156,47 @@ impl CredentialLock {
             }
         }
 
-        // On non-Unix, the file open with write mode provides basic mutual exclusion
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            let handle = file.as_raw_handle();
+            // Lock the entire file exclusively (LOCKFILE_EXCLUSIVE_LOCK).
+            // LOCKFILE_FAIL_IMMEDIATELY is NOT set — this blocks until the
+            // lock is acquired, matching Unix `flock(LOCK_EX)` semantics.
+            const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x0000_0002;
+            // Overlapped structure required by `LockFileEx` even for synchronous
+            // calls. A zero-initialized `OVERLAPPED` is sufficient — Win32 docs
+            // allow a null event handle / completion port for blocking locks.
+            let overlapped = std::mem::MaybeUninit::<
+                windows_sys::Win32::System::IO::OVERLAPPED,
+            >::zeroed();
+            // SAFETY: all-zero is a valid `OVERLAPPED` for sync `LockFileEx`.
+            let mut overlapped = unsafe { overlapped.assume_init() };
+            let ret = unsafe {
+                windows_sys::Win32::Storage::FileSystem::LockFileEx(
+                    handle as _,
+                    LOCKFILE_EXCLUSIVE_LOCK,
+                    0,
+                    // NumberOfBytesToLockLow / High = 0 → lock entire file
+                    0xFFFF_FFFF,
+                    0xFFFF_FFFF,
+                    &mut overlapped,
+                )
+            };
+            if ret == 0 {
+                return Err(format!(
+                    "Failed to acquire credential lock: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+        }
+
+        // Lock is released when the File is dropped:
+        //   Unix: flock is released on close.
+        //   Windows: CloseHandle (via Drop) releases the LockFileEx lock.
         Ok(Self { _file: file })
     }
 }
-
-// Lock is released when the File is dropped (flock is released on close)
 
 /// Check if Claude Code credentials exist
 #[must_use]
@@ -306,7 +357,7 @@ fn resolve_new_refresh_token(
 }
 
 async fn refresh_and_load(
-    path: &PathBuf,
+    path: &std::path::Path,
     oauth: &ClaudeAiOauth,
 ) -> Result<LoadedCredentials, String> {
     const MIN_EXPIRES_IN_SECS: i64 = 60;
@@ -388,10 +439,32 @@ async fn refresh_and_load(
         }),
     };
 
-    let json = serde_json::to_string_pretty(&updated)
-        .map_err(|e| format!("Failed to serialize updated credentials: {e}"))?;
+    // Persist via the shared writer (symlink guard + 0600 perms + typed
+    // FileError on the way out). See crosslink #492.
+    write_credentials_file(path, &updated)?;
 
-    // Reject symlinks before writing refreshed tokens
+    info!("Token refreshed successfully (expires in {}s)", expires_in);
+
+    Ok(LoadedCredentials {
+        access_token: new_access_token,
+        subscription_type: oauth.subscription_type.clone(),
+        rate_limit_tier: oauth.rate_limit_tier.clone(),
+        scopes: new_scopes,
+    })
+}
+
+/// Serialize and write a [`CredentialsFile`] to `path`.
+///
+/// Shared by [`refresh_and_load`] (token refresh) and [`store_credentials`]
+/// (initial login). Refuses to follow a symlink, creates the parent directory
+/// if needed, and replaces the target **atomically** (temp file + rename) with
+/// `0600` perms on Unix — a crash or concurrent reader can never observe a
+/// half-written credentials file. See review H1/H2.
+fn write_credentials_file(
+    path: &std::path::Path,
+    creds: &CredentialsFile,
+) -> Result<(), String> {
+    // Reject symlinks before writing tokens (symlink-swap attack guard).
     if path
         .symlink_metadata()
         .is_ok_and(|m| m.file_type().is_symlink())
@@ -402,24 +475,236 @@ async fn refresh_and_load(
         ));
     }
 
-    // Same typed-error rationale as the read path above — see crosslink #492.
-    crate::file_error::write_file(path, &json).map_err(|e| e.to_string())?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("credentials path {} has no parent directory", path.display()))?;
+    // First login may predate the config directory.
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
 
-    // Preserve original file permissions (0600)
+    let json = serde_json::to_string_pretty(creds)
+        .map_err(|e| format!("Failed to serialize credentials: {e}"))?;
+
+    // Atomic replace: write a sibling temp file, then rename over the target.
+    // `std::fs::write` truncates in place, so a crash or a concurrent reader
+    // (Claude Code, openclaude, or our own chat refresh) mid-write could
+    // corrupt this shared file. rename is atomic on a single volume on both
+    // Unix and Windows, keeping every reader consistent even where the advisory
+    // lock is weak (it is a no-op on Windows). The pid suffix avoids collisions
+    // between concurrent writers. See review H1/H2.
+    let tmp = parent.join(format!(".credentials.json.tmp.{}", std::process::id()));
+    if let Err(e) = write_secret_tmp(&tmp, json.as_bytes()) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(format!("Failed to write {}: {e}", tmp.display()));
+    }
+    std::fs::rename(&tmp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("Failed to replace {}: {e}", path.display())
+    })
+}
+
+/// Write `bytes` to `tmp`, tightening to `0600` before the secret lands on disk
+/// (Unix) and best-effort fsyncing for durability. Atomicity is provided by the
+/// caller's subsequent rename, so an fsync failure is logged, not fatal.
+fn write_secret_tmp(tmp: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(tmp)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    f.write_all(bytes)?;
+    if let Err(e) = f.sync_all() {
+        tracing::warn!("fsync of credentials temp file failed (continuing): {e}");
+    }
+    Ok(())
+}
+
+/// Read and parse an existing credentials file's `claudeAiOauth` section, or
+/// `None` if absent / unreadable / symlinked. Used to preserve fields the token
+/// endpoint omits on a fresh login (refresh token, subscription, rate-limit).
+fn read_existing_oauth(path: &std::path::Path) -> Option<ClaudeAiOauth> {
+    if !path.exists()
+        || path
+            .symlink_metadata()
+            .is_ok_and(|m| m.file_type().is_symlink())
+    {
+        return None;
+    }
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<CredentialsFile>(&c).ok())
+        .and_then(|c| c.claude_ai_oauth)
+}
+
+/// Merge a freshly obtained token with any pre-existing on-disk values.
+///
+/// Fields the Anthropic token endpoint does not return on a fresh login —
+/// `refresh_token`, `subscriptionType`, `rateLimitTier` — fall back to the
+/// existing file rather than being clobbered with `None`. Preserving the
+/// refresh token in particular keeps automatic refresh working when a login
+/// response omits it (review M1). Pure (no I/O) so it is unit-testable.
+fn merge_oauth_fields(
+    access_token: &str,
+    refresh_token: Option<&str>,
+    expires_at_ms: i64,
+    scopes: Vec<String>,
+    subscription_type: Option<String>,
+    rate_limit_tier: Option<String>,
+    existing: Option<&ClaudeAiOauth>,
+) -> ClaudeAiOauth {
+    ClaudeAiOauth {
+        access_token: access_token.to_string(),
+        refresh_token: refresh_token
+            .map(String::from)
+            .or_else(|| existing.and_then(|o| o.refresh_token.clone())),
+        expires_at: expires_at_ms,
+        scopes,
+        subscription_type: subscription_type
+            .or_else(|| existing.and_then(|o| o.subscription_type.clone())),
+        rate_limit_tier: rate_limit_tier
+            .or_else(|| existing.and_then(|o| o.rate_limit_tier.clone())),
+    }
+}
+
+/// Persist OAuth credentials to Claude Code's `~/.claude/.credentials.json`
+/// store in the `claudeAiOauth` format.
+///
+/// This makes `OpenClaudia` a first-class *producer* of the shared credential
+/// file (previously it only read it): a token obtained via `openclaudia auth`
+/// is now usable by the chat/proxy paths through [`load_credentials`] without
+/// Claude Code or another fork being installed.
+///
+/// The Anthropic token endpoint does not return `subscriptionType` /
+/// `rateLimitTier`, so when the caller passes `None` for those, any values
+/// already present in an existing credentials file (e.g. from a prior Claude
+/// Code login) are preserved rather than clobbered.
+///
+/// `expires_at_ms` is milliseconds since the Unix epoch (matching
+/// [`ClaudeAiOauth::expires_at`]).
+///
+/// # Errors
+///
+/// Returns an error if the home directory cannot be resolved, the target is a
+/// symlink, or the file cannot be written.
+pub fn store_credentials(
+    access_token: &str,
+    refresh_token: Option<&str>,
+    expires_at_ms: i64,
+    scopes: Vec<String>,
+    subscription_type: Option<String>,
+    rate_limit_tier: Option<String>,
+) -> Result<(), String> {
+    // Hold the advisory lock across read-merge-write so a concurrent refresh
+    // (our chat path, or another OpenClaudia process) cannot interleave.
+    let _lock = CredentialLock::acquire()?;
+    let path = credentials_path().ok_or("Cannot determine credentials directory")?;
+
+    // Preserve refresh token / subscription / rate-limit metadata the token
+    // endpoint omits on a fresh login, rather than clobbering them with None.
+    let need_existing =
+        refresh_token.is_none() || subscription_type.is_none() || rate_limit_tier.is_none();
+    let existing = if need_existing {
+        read_existing_oauth(&path)
+    } else {
+        None
+    };
+
+    let merged = merge_oauth_fields(
+        access_token,
+        refresh_token,
+        expires_at_ms,
+        scopes,
+        subscription_type,
+        rate_limit_tier,
+        existing.as_ref(),
+    );
+    if merged.refresh_token.is_none() {
+        tracing::warn!(
+            "store_credentials: login returned no refresh token and none on disk; \
+             automatic token refresh will be unavailable until the next login"
+        );
     }
 
-    info!("Token refreshed successfully (expires in {}s)", expires_in);
+    write_credentials_file(
+        &path,
+        &CredentialsFile {
+            claude_ai_oauth: Some(merged),
+        },
+    )
+}
 
-    Ok(LoadedCredentials {
-        access_token: new_access_token,
+/// A read-only snapshot of the stored Claude Code credentials, for status
+/// display. Unlike [`load_credentials`], reading this does **not** trigger a
+/// token refresh or any network call.
+#[derive(Debug, Clone)]
+pub struct CredentialStatus {
+    /// Token expiry, milliseconds since the Unix epoch.
+    pub expires_at_ms: i64,
+    /// Whether the token is already past `expires_at_ms`.
+    pub expired: bool,
+    /// Whether the token is within the refresh buffer of expiry (not yet
+    /// expired, but the next chat call will transparently refresh it).
+    pub expires_soon: bool,
+    /// Whether the token carries the `user:inference` scope required for chat.
+    pub has_inference_scope: bool,
+    /// Subscription tier (`pro`, `max`, …) if recorded.
+    pub subscription_type: Option<String>,
+}
+
+/// Peek at the stored Claude Code credentials without refreshing them.
+///
+/// Returns `Ok(None)` when no credentials file (or no `claudeAiOauth` section)
+/// is present. Used by `openclaudia auth --status` to report the real,
+/// chat-usable credential store (the file [`load_credentials`] reads).
+///
+/// # Errors
+///
+/// Returns an error if the file exists but is a symlink, or cannot be read or
+/// parsed.
+pub fn peek_credentials() -> Result<Option<CredentialStatus>, String> {
+    let Some(path) = credentials_path().filter(|p| p.exists()) else {
+        return Ok(None);
+    };
+    if path
+        .symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_symlink())
+    {
+        return Err(format!(
+            "Credentials file {} is a symlink — refusing to read for security",
+            path.display()
+        ));
+    }
+    let content = crate::file_error::read_file(&path).map_err(|e| e.to_string())?;
+    let creds: CredentialsFile = serde_json::from_str(&content)
+        .map_err(crate::file_error::FileError::json_with_path(&path))
+        .map_err(|e| e.to_string())?;
+    let Some(oauth) = creds.claude_ai_oauth else {
+        return Ok(None);
+    };
+    Ok(Some(status_from_oauth(
+        &oauth,
+        chrono::Utc::now().timestamp_millis(),
+    )))
+}
+
+/// Compute a [`CredentialStatus`] from a parsed `claudeAiOauth` blob at a given
+/// clock value. Pure (no I/O) so the expiry/scope logic is unit-testable.
+fn status_from_oauth(oauth: &ClaudeAiOauth, now_ms: i64) -> CredentialStatus {
+    CredentialStatus {
+        expires_at_ms: oauth.expires_at,
+        expired: now_ms >= oauth.expires_at,
+        // Mirrors load_credentials' refresh trigger: within the buffer, the
+        // next chat call will transparently refresh.
+        expires_soon: now_ms < oauth.expires_at && now_ms + REFRESH_BUFFER_MS >= oauth.expires_at,
+        has_inference_scope: oauth.scopes.iter().any(|s| s == "user:inference"),
         subscription_type: oauth.subscription_type.clone(),
-        rate_limit_tier: oauth.rate_limit_tier.clone(),
-        scopes: new_scopes,
-    })
+    }
 }
 
 /// Build the HTTP headers for Anthropic API with OAuth Bearer auth.
@@ -741,6 +1026,157 @@ mod tests {
     fn test_has_credentials_function() {
         // Just verify it doesn't panic
         let _ = has_claude_code_credentials();
+    }
+
+    #[test]
+    fn write_credentials_file_round_trips_with_claude_code_keys() {
+        // `store_credentials` and `refresh_and_load` both serialize through
+        // `write_credentials_file`; this pins the on-disk shape to Claude
+        // Code's camelCase keys so the file stays readable by `load_credentials`,
+        // by Claude Code itself, and by forks like @gitlawb/openclaude. Uses a
+        // temp path — never the real ~/.claude.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(".credentials.json");
+        let creds = CredentialsFile {
+            claude_ai_oauth: Some(ClaudeAiOauth {
+                access_token: "sk-ant-oat01-TESTTOKEN".to_string(),
+                refresh_token: Some("sk-ant-ort01-REFRESH".to_string()),
+                expires_at: 1_999_999_999_999,
+                scopes: vec!["user:inference".to_string(), "user:profile".to_string()],
+                subscription_type: Some("pro".to_string()),
+                rate_limit_tier: Some("default_claude_ai".to_string()),
+            }),
+        };
+
+        write_credentials_file(&path, &creds).expect("write should succeed");
+
+        let content = std::fs::read_to_string(&path).expect("file should exist");
+        // Canonical Claude Code key names — drift here breaks interop.
+        assert!(
+            content.contains("\"claudeAiOauth\""),
+            "missing claudeAiOauth: {content}"
+        );
+        assert!(
+            content.contains("\"accessToken\""),
+            "missing accessToken: {content}"
+        );
+        assert!(
+            content.contains("\"expiresAt\""),
+            "missing expiresAt: {content}"
+        );
+
+        let parsed: CredentialsFile = serde_json::from_str(&content).expect("parse");
+        let oauth = parsed.claude_ai_oauth.expect("oauth section round-trips");
+        assert_eq!(oauth.access_token, "sk-ant-oat01-TESTTOKEN");
+        assert_eq!(oauth.expires_at, 1_999_999_999_999);
+        assert_eq!(oauth.subscription_type.as_deref(), Some("pro"));
+        assert!(oauth.scopes.iter().any(|s| s == "user:inference"));
+    }
+
+    #[test]
+    fn merge_oauth_fields_preserves_refresh_token_when_login_omits_it() {
+        // review M1: a login response without a refresh_token must NOT wipe the
+        // existing one, or automatic refresh silently breaks on next expiry.
+        let existing = ClaudeAiOauth {
+            access_token: "old".into(),
+            refresh_token: Some("keep-me".into()),
+            expires_at: 1,
+            scopes: vec![],
+            subscription_type: Some("max".into()),
+            rate_limit_tier: Some("tier-x".into()),
+        };
+        let merged = merge_oauth_fields(
+            "new-access",
+            None, // login returned no refresh token
+            42,
+            vec!["user:inference".into()],
+            None, // no subscription from token endpoint
+            None, // no rate limit from token endpoint
+            Some(&existing),
+        );
+        assert_eq!(merged.access_token, "new-access");
+        assert_eq!(merged.expires_at, 42);
+        assert_eq!(merged.refresh_token.as_deref(), Some("keep-me"));
+        assert_eq!(merged.subscription_type.as_deref(), Some("max"));
+        assert_eq!(merged.rate_limit_tier.as_deref(), Some("tier-x"));
+    }
+
+    #[test]
+    fn merge_oauth_fields_prefers_fresh_values_over_existing() {
+        let existing = ClaudeAiOauth {
+            access_token: "old".into(),
+            refresh_token: Some("old-refresh".into()),
+            expires_at: 1,
+            scopes: vec![],
+            subscription_type: Some("pro".into()),
+            rate_limit_tier: None,
+        };
+        let merged = merge_oauth_fields(
+            "new-access",
+            Some("new-refresh"),
+            99,
+            vec!["user:inference".into()],
+            Some("max".into()),
+            Some("tier-new".into()),
+            Some(&existing),
+        );
+        assert_eq!(merged.refresh_token.as_deref(), Some("new-refresh"));
+        assert_eq!(merged.subscription_type.as_deref(), Some("max"));
+        assert_eq!(merged.rate_limit_tier.as_deref(), Some("tier-new"));
+    }
+
+    #[test]
+    fn merge_oauth_fields_without_existing_keeps_none() {
+        let merged = merge_oauth_fields("a", None, 7, vec![], None, None, None);
+        assert!(merged.refresh_token.is_none());
+        assert!(merged.subscription_type.is_none());
+        assert!(merged.rate_limit_tier.is_none());
+    }
+
+    #[test]
+    fn status_from_oauth_flags_expiry_and_scope() {
+        let base = ClaudeAiOauth {
+            access_token: "t".into(),
+            refresh_token: None,
+            expires_at: 0,
+            scopes: vec!["user:inference".into(), "user:profile".into()],
+            subscription_type: Some("pro".into()),
+            rate_limit_tier: None,
+        };
+
+        // Valid, far from expiry.
+        let far = ClaudeAiOauth {
+            expires_at: REFRESH_BUFFER_MS * 100,
+            ..base.clone()
+        };
+        let s = status_from_oauth(&far, 0);
+        assert!(!s.expired && !s.expires_soon && s.has_inference_scope);
+        assert_eq!(s.subscription_type.as_deref(), Some("pro"));
+
+        // Already expired.
+        let expired = ClaudeAiOauth {
+            expires_at: 100,
+            ..base.clone()
+        };
+        let s = status_from_oauth(&expired, 200);
+        assert!(s.expired && !s.expires_soon);
+
+        // Within the refresh buffer (not yet expired).
+        let soon = ClaudeAiOauth {
+            expires_at: REFRESH_BUFFER_MS,
+            ..base.clone()
+        };
+        let s = status_from_oauth(&soon, 1);
+        assert!(!s.expired && s.expires_soon);
+
+        // Missing inference scope.
+        let no_inf = ClaudeAiOauth {
+            scopes: vec!["user:profile".into()],
+            expires_at: REFRESH_BUFFER_MS * 100,
+            ..base
+        };
+        let s = status_from_oauth(&no_inf, 0);
+        assert!(!s.has_inference_scope);
     }
 
     // --- Regression guard for crosslink #272: beta-header string drift ---

--- a/src/cli/chat_repl.rs
+++ b/src/cli/chat_repl.rs
@@ -57,6 +57,7 @@ use rustyline::error::ReadlineError;
 /// public `cmd_chat` signature stays a thin wrapper.
 pub struct ChatReplArgs {
     pub model_override: Option<String>,
+    pub target_override: Option<String>,
     pub resume: bool,
     pub session_id: Option<String>,
     pub coordinator: bool,
@@ -152,6 +153,7 @@ impl ChatRepl {
     /// initialized REPL. `Ok(None)` means setup printed a user-facing
     /// error and the caller should exit cleanly (matches the original
     /// `return Ok(())` branches of `cmd_chat`).
+    #[allow(clippy::too_many_lines)]
     pub async fn new(args: ChatReplArgs) -> anyhow::Result<Option<Self>> {
         use openclaudia::rules::RulesEngine;
 
@@ -172,6 +174,11 @@ impl ChatRepl {
         };
 
         let mut config = config;
+        // Explicit `--target` wins first; a model-name override may still
+        // re-detect the provider below (mirrors `cmd_tui`).
+        if let Some(ref target) = args.target_override {
+            config.proxy.target.clone_from(target);
+        }
         if let Some(ref m) = args.model_override {
             let detected = openclaudia::proxy::determine_provider(m, &config);
             if detected != config.proxy.target {

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -10,38 +10,69 @@ pub async fn cmd_auth(status: bool, logout: bool) -> anyhow::Result<()> {
 
     // Handle --status flag
     if status {
-        let sessions: Vec<_> = {
-            let _store = OAuthStore::new();
-            let persist_path =
-                dirs::data_local_dir().map(|d| d.join("openclaudia").join("oauth_sessions.json"));
-
-            persist_path
-                .filter(|path| path.exists())
-                .and_then(|path| std::fs::read_to_string(&path).ok())
-                .and_then(|content| {
-                    serde_json::from_str::<std::collections::HashMap<String, serde_json::Value>>(
-                        &content,
-                    )
-                    .ok()
-                })
-                .map(|sessions| sessions.into_iter().collect())
-                .unwrap_or_default()
-        };
-
-        if sessions.is_empty() {
-            println!("Not authenticated with Claude Max.");
-            println!("Run 'openclaudia auth' to authenticate.");
-        } else {
-            println!("Authenticated with Claude Max.");
-            println!("Sessions: {}", sessions.len());
-            for (id, data) in &sessions {
-                let expires = data
-                    .get("credentials")
-                    .and_then(|c| c.get("expires_at"))
-                    .and_then(|e| e.as_str())
-                    .unwrap_or("unknown");
-                println!("  {} (expires: {})", safe_truncate(id, 8), expires);
+        // Primary: the chat-usable Claude credential store
+        // (<config-dir>/.credentials.json) — what the chat/proxy paths use via
+        // `load_credentials`, and what `openclaudia auth` now writes.
+        let creds_path = openclaudia::claude_credentials::credentials_path().map_or_else(
+            || "~/.claude/.credentials.json".to_string(),
+            |p| p.display().to_string(),
+        );
+        match openclaudia::claude_credentials::peek_credentials() {
+            Ok(Some(s)) => {
+                let now_ms = chrono::Utc::now().timestamp_millis();
+                let remaining_secs = (s.expires_at_ms - now_ms).max(0) / 1000;
+                println!("Claude credentials ({creds_path}):");
+                println!(
+                    "  subscription : {}",
+                    s.subscription_type.as_deref().unwrap_or("unknown")
+                );
+                println!(
+                    "  inference    : {}",
+                    if s.has_inference_scope {
+                        "yes"
+                    } else {
+                        "no (chat will fail)"
+                    }
+                );
+                if s.expired {
+                    println!("  status       : expired (auto-refreshes on next use)");
+                } else if s.expires_soon {
+                    println!("  status       : valid, expiring soon (auto-refreshes on next use)");
+                } else {
+                    println!(
+                        "  status       : valid (~{}h{}m remaining)",
+                        remaining_secs / 3600,
+                        (remaining_secs % 3600) / 60
+                    );
+                }
             }
+            Ok(None) => {
+                println!("No Claude credentials at {creds_path}.");
+                println!("Run 'openclaudia auth', or log in with Claude Code / openclaude.");
+            }
+            Err(e) => {
+                eprintln!("Could not read {creds_path}: {e}");
+            }
+        }
+
+        // Secondary: OpenClaudia's own device-flow OAuth session store. Separate
+        // from the file above; empty unless `openclaudia auth` has run here.
+        let session_count = dirs::data_local_dir()
+            .map(|d| d.join("openclaudia").join("oauth_sessions.json"))
+            .filter(|path| path.exists())
+            .and_then(|path| std::fs::read_to_string(&path).ok())
+            .and_then(|content| {
+                serde_json::from_str::<std::collections::HashMap<String, serde_json::Value>>(
+                    &content,
+                )
+                .ok()
+            })
+            .map_or(0, |sessions| sessions.len());
+        println!();
+        if session_count == 0 {
+            println!("Native OAuth session store: empty.");
+        } else {
+            println!("Native OAuth session store: {session_count} session(s).");
         }
         return Ok(());
     }
@@ -140,6 +171,31 @@ pub async fn cmd_auth(status: bool, logout: bool) -> anyhow::Result<()> {
     } else {
         println!("Using Bearer token authentication (personal Claude Max account)");
         println!("  Granted scopes: {}", session.granted_scopes.join(", "));
+    }
+
+    // Persist to Claude Code's standard credential store so OpenClaudia's
+    // chat/proxy paths (`claude_credentials::load_credentials`) can use this
+    // login directly — no Claude Code install required. Gated on the inference
+    // scope the chat path requires; the token endpoint omits subscription /
+    // rate-limit metadata, so pass None (store_credentials preserves any
+    // existing values).
+    if session.granted_scopes.iter().any(|s| s == "user:inference") {
+        match openclaudia::claude_credentials::store_credentials(
+            &session.credentials.access_token,
+            session.credentials.refresh_token.as_deref(),
+            session.credentials.expires_at.timestamp_millis(),
+            session.granted_scopes.clone(),
+            None,
+            None,
+        ) {
+            Ok(()) => println!("Saved Claude credentials to ~/.claude/.credentials.json"),
+            Err(e) => eprintln!("Warning: could not write ~/.claude/.credentials.json: {e}"),
+        }
+    } else {
+        eprintln!(
+            "Note: granted scopes lack 'user:inference'; \
+             skipped writing ~/.claude/.credentials.json"
+        );
     }
 
     let session_id = session.id.clone();

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -32,7 +32,7 @@ pub fn cmd_init(force: bool) -> anyhow::Result<()> {
 proxy:
   port: 8080
   host: "127.0.0.1"
-  target: anthropic  # Default provider: anthropic, openai, google, zai, deepseek, qwen
+  target: anthropic  # Default provider: anthropic, openai, google, zai, deepseek, qwen, minimax, kimi
 
 providers:
   anthropic:
@@ -52,6 +52,14 @@ providers:
   deepseek:
     base_url: https://api.deepseek.com
     # api_key: ${DEEPSEEK_API_KEY}
+  # Kimi/Moonshot (OpenAI-compatible) - Models: kimi-k2.7-code
+  kimi:
+    base_url: https://api.moonshot.cn
+    # api_key: ${KIMI_API_KEY}
+  # MiniMax (OpenAI-compatible) - Models: MiniMax-M3
+  minimax:
+    base_url: https://api.minimax.io/v1
+    # api_key: ${MINIMAX_API_KEY}
   # Qwen/Alibaba (OpenAI-compatible) - Models: qwen-turbo, qwen-plus
   qwen:
     base_url: https://dashscope.aliyuncs.com/compatible-mode

--- a/src/cli/repl/models.rs
+++ b/src/cli/repl/models.rs
@@ -4,7 +4,7 @@ use openclaudia::{config, providers};
 pub fn get_available_models(provider: &str) -> Vec<&'static str> {
     match provider {
         "anthropic" => vec![
-            "claude-opus-4-6",
+            "claude-opus-4-8",
             "claude-sonnet-4-6",
             "claude-haiku-4-5-20251001",
             "claude-sonnet-4-5-20250929",
@@ -14,7 +14,7 @@ pub fn get_available_models(provider: &str) -> Vec<&'static str> {
             "claude-opus-4-20250514",
         ],
         "openai" => vec![
-            "gpt-5.2",
+            "gpt-5.5",
             "gpt-5.2-codex",
             "gpt-5",
             "gpt-5-mini",
@@ -41,9 +41,11 @@ pub fn get_available_models(provider: &str) -> Vec<&'static str> {
             "glm-4.6",
             "glm-4.5-flash",
         ],
-        "deepseek" => vec!["deepseek-chat", "deepseek-reasoner"],
+        "deepseek" => vec!["deepseek-v4-pro", "deepseek-reasoner"],
+        "kimi" => vec!["kimi-k2.7-code"],
+        "minimax" => vec!["minimax-m3"],
         "qwen" => vec![
-            "qwen3.5-plus",
+            "qwen-3.7-plus",
             "qwen3-max",
             "qwen-plus",
             "qwen-turbo",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -181,6 +181,16 @@ pub fn load_config() -> Result<AppConfig, ConfigError> {
         .set_default(
             "providers.qwen.base_url",
             "https://dashscope.aliyuncs.com/compatible-mode",
+        )?
+        // MiniMax (OpenAI-compatible)
+        .set_default(
+            "providers.minimax.base_url",
+            "https://api.minimax.io/v1",
+        )?
+        // Kimi/Moonshot (OpenAI-compatible)
+        .set_default(
+            "providers.kimi.base_url",
+            "https://api.moonshot.cn",
         )?;
 
     // Load from project config file
@@ -233,6 +243,12 @@ pub fn load_config() -> Result<AppConfig, ConfigError> {
     }
     if let Ok(key) = std::env::var("QWEN_API_KEY") {
         builder = maybe_set_api_key(builder, "providers.qwen.api_key", key)?;
+    }
+    if let Ok(key) = std::env::var("KIMI_API_KEY") {
+        builder = maybe_set_api_key(builder, "providers.kimi.api_key", key)?;
+    }
+    if let Ok(key) = std::env::var("MINIMAX_API_KEY") {
+        builder = maybe_set_api_key(builder, "providers.minimax.api_key", key)?;
     }
 
     // `ApiKey::deserialize` (invoked transitively here) enforces non-empty,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ use openclaudia::{
     config, guardrails, memory,
     permissions::PermissionManager,
     plugins, prompt,
-    proxy::normalize_base_url,
+    proxy::{self, normalize_base_url},
+    providers::get_adapter,
     tools::{self},
     tui, vdd,
 };
@@ -44,6 +45,10 @@ struct Cli {
     /// Model to use for chat
     #[arg(short, long, global = true)]
     model: Option<String>,
+
+    /// Target provider (use default model for that provider)
+    #[arg(short = 't', long, global = true)]
+    target: Option<String>,
 
     /// Resume the most recent chat session
     #[arg(long, alias = "continue")]
@@ -77,6 +82,10 @@ struct Cli {
         value_parser = PossibleValuesParser::new(openclaudia::modes::SUPPORTED_PRESETS),
     )]
     mode: Option<String>,
+
+    /// One-shot print mode: send a single message and print response to stdout
+    #[arg(short = 'p', long, global = true)]
+    print: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -212,11 +221,18 @@ async fn main() -> anyhow::Result<()> {
     let _ =
         openclaudia::migrations::run_all(&openclaudia::migrations::MigrationContext::from_env());
 
+    // One-shot print mode
+    if let Some(prompt) = cli.print {
+        cmd_print(cli.model, cli.target, prompt).await?;
+        return Ok(());
+    }
+
     match cli.command {
         None if cli.tui_mode => {
             // Legacy rustyline REPL (--tui-mode is now the escape hatch name, kept for compat)
             cmd_chat(
                 cli.model,
+                cli.target,
                 cli.resume,
                 cli.session_id,
                 cli.coordinator,
@@ -227,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
         }
         None => {
             // Default: full-screen TUI
-            cmd_tui(cli.model).await
+            cmd_tui(cli.model, cli.target).await
         }
         Some(Commands::Init { force }) => cli::commands::init::cmd_init(force),
         Some(Commands::Auth { status, logout }) => {
@@ -253,11 +269,203 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+/// Extract the incremental assistant text from one streaming SSE `data:`
+/// JSON object, supporting all wire shapes the print path may receive:
+///   * OpenAI-compatible streaming: `choices[0].delta.content`
+///   * Anthropic-native streaming (`/v1/messages`, incl. OAuth):
+///     `{"type":"content_block_delta", "delta":{"text":"..."}}`
+///   * Anthropic-native non-streaming: `content[*].text` (an array of
+///     content blocks — only `type == "text"` blocks carry user-visible
+///     text; `type == "tool_use"` blocks hold tool-call payloads we
+///     don't print here).
+///
+/// Returns `None` for non-text events (role openers, `message_stop`,
+/// thinking deltas, tool-call deltas, and message-level events with
+/// no extractable text) so the caller prints only answer text.
+fn extract_stream_delta(json: &serde_json::Value) -> Option<String> {
+    // OpenAI-compatible streaming delta.
+    if let Some(text) = json["choices"][0]["delta"]["content"].as_str() {
+        return Some(text.to_string());
+    }
+    // Anthropic streaming content_block_delta.
+    if json["type"].as_str() == Some("content_block_delta") {
+        if let Some(text) = json["delta"]["text"].as_str() {
+            return Some(text.to_string());
+        }
+    }
+    // Anthropic non-streaming message — `content` is an array of blocks.
+    // We extract only `type == "text"` blocks and concatenate them; any
+    // tool_use / thinking / image blocks are skipped. If the array is
+    // absent, or contains no text blocks, returns None so the caller's
+    // "no output" behaviour matches the streaming case.
+    if let Some(arr) = json["content"].as_array() {
+        let mut joined = String::new();
+        for block in arr {
+            if block["type"].as_str() == Some("text") {
+                if let Some(text) = block["text"].as_str() {
+                    joined.push_str(text);
+                }
+            }
+        }
+        if !joined.is_empty() {
+            return Some(joined);
+        }
+    }
+    None
+}
+
+/// One-shot print mode: load config, resolve auth, send one message, print response.
+#[allow(clippy::too_many_lines)]
+async fn cmd_print(
+    model_override: Option<String>,
+    target_override: Option<String>,
+    prompt: String,
+) -> anyhow::Result<()> {
+    use futures::StreamExt;
+    use std::io::Write;
+
+    let mut config = config::load_config().map_err(|e| {
+        if config::config_file_exists() {
+            eprintln!("Failed to parse configuration: {e}");
+            anyhow::anyhow!("invalid configuration: {e}")
+        } else {
+            eprintln!("No configuration found. Run 'openclaudia init' first.");
+            anyhow::anyhow!("no configuration found")
+        }
+    })?;
+
+    if let Some(ref target) = target_override {
+        config.proxy.target.clone_from(target);
+    }
+    if let Some(ref model) = model_override {
+        let detected = openclaudia::proxy::determine_provider(model, &config);
+        if detected != config.proxy.target {
+            config.proxy.target = detected;
+        }
+    }
+
+    let Some(provider) = config.active_provider() else {
+        anyhow::bail!("no provider configured for target '{}'", config.proxy.target);
+    };
+
+    let Some(ChatAuth {
+        api_key: key_opt,
+        claude_code_token,
+    }) = resolve_chat_auth(&config.proxy.target, provider).await?
+    else {
+        anyhow::bail!("could not resolve authentication for target '{}'", config.proxy.target);
+    };
+    if key_opt.is_none() && claude_code_token.is_none() {
+        anyhow::bail!(
+            "no API key or Claude Code OAuth credentials for target '{}'",
+            config.proxy.target
+        );
+    }
+
+    let model = resolve_model_name(model_override, provider.model.clone(), &config.proxy.target);
+
+    let request = proxy::ChatCompletionRequest {
+        model: model.clone(),
+        messages: vec![
+            proxy::ChatMessage {
+                role: "user".to_string(),
+                content: proxy::MessageContent::Text(prompt),
+                name: None,
+                tool_call_id: None,
+                tool_calls: None,
+            },
+        ],
+        temperature: None,
+        max_tokens: Some(4096),
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        extra: std::collections::HashMap::new(),
+    };
+
+    let adapter = get_adapter(&config.proxy.target)
+        .map_err(|e| anyhow::anyhow!("unknown provider: {e}"))?;
+
+    // One-shot print skips extended thinking: the Anthropic adapter would
+    // set `thinking.budget_tokens` without raising `max_tokens` above it
+    // (a 400 from /v1/messages), and thinking deltas are never printed here.
+    let mut transformed = adapter
+        .transform_request(&request)
+        .map_err(|e| anyhow::anyhow!("request transform error: {e}"))?;
+
+    // Claude Code OAuth requires the exact Claude Code system-prompt prefix
+    // block — the Anthropic OAuth endpoint validates it. Mirrors the TUI /
+    // pipeline path (`build_chat_request_body`).
+    if claude_code_token.is_some() {
+        openclaudia::claude_credentials::inject_system_prompt(&mut transformed);
+    }
+
+    let extra_headers: Vec<(String, String)> = provider
+        .headers
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let url = openclaudia::pipeline::resolve_endpoint(
+        &config.proxy.target,
+        &model,
+        &provider.base_url,
+        claude_code_token.as_deref(),
+    )?;
+    let headers = openclaudia::pipeline::resolve_headers(
+        &config.proxy.target,
+        key_opt.as_ref(),
+        claude_code_token.as_deref(),
+        &extra_headers,
+    )?;
+
+    let client = reqwest::Client::new();
+    let mut req = client.post(&url).json(&transformed);
+    for (key, value) in &headers {
+        req = req.header(key.as_str(), value.as_str());
+    }
+
+    let response = req.send().await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("API error {}: {body}", status.as_u16());
+    }
+
+    // Stream SSE response
+    let mut stream = response.bytes_stream();
+    let mut buf = String::new();
+
+    while let Some(result) = stream.next().await {
+        let chunk = result?;
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+
+        // Process complete SSE lines
+        while let Some(pos) = buf.find('\n') {
+            let line = buf[..pos].trim().to_string();
+            buf = buf[pos + 1..].to_string();
+
+            if line.is_empty() || line == "data: [DONE]" {
+                continue;
+            }
+            if let Some(data) = line.strip_prefix("data: ") {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                    if let Some(delta) = extract_stream_delta(&json) {
+                        print!("{delta}");
+                        let _ = std::io::stdout().flush();
+                    }
+                }
+            }
+        }
+    }
+    println!();
+    Ok(())
+}
+
 /// Full-screen TUI mode (default when no subcommand).
 ///
 /// Loads config, resolves the provider/model/API key, builds the system prompt,
 /// then launches the ratatui interactive TUI with the API pipeline wired up.
-async fn cmd_tui(model_override: Option<String>) -> anyhow::Result<()> {
+async fn cmd_tui(model_override: Option<String>, target_override: Option<String>) -> anyhow::Result<()> {
     // Crosslink #797: every configuration-load / provider-resolve /
     // auth-resolve failure path used to print to stderr and return
     // `Ok(())`, giving exit code 0 even on a broken setup. `set -e`
@@ -276,6 +484,11 @@ async fn cmd_tui(model_override: Option<String>) -> anyhow::Result<()> {
         }
     })?;
 
+    // Auto-detect provider from model name
+    // Override target if --target/-t is provided
+    if let Some(ref target) = target_override {
+        config.proxy.target.clone_from(target);
+    }
     // Auto-detect provider from model name
     if let Some(ref model) = model_override {
         let detected = openclaudia::proxy::determine_provider(model, &config);
@@ -852,16 +1065,18 @@ fn chdir_to_git_root() {
 /// against the matching adapter, giving us a compile-/test-time guard
 /// against silent drift (`claude-opus-4-6` → `4-7` → `4-8` …).
 const DEFAULT_MODELS_BY_TARGET: &[(&str, &str)] = &[
-    ("anthropic", "claude-opus-4-6"),
-    ("google", "gemini-2.5-flash"),
-    ("zai", "glm-5"),
-    ("deepseek", "deepseek-chat"),
-    ("qwen", "qwen3.5-plus"),
+    ("anthropic", "claude-opus-4-8"),
+    ("google", "gemini-3.1-pro-preview"),
+    ("zai", "glm-5.2"),
+    ("deepseek", "deepseek-v4-pro"),
+    ("qwen", "qwen-3.7-plus"),
+    ("kimi", "kimi-k2.7-code"),
+    ("minimax", "minimax-m3"),
 ];
 
 /// Fallback model for targets not listed in [`DEFAULT_MODELS_BY_TARGET`].
 /// Currently every non-table target is treated as OpenAI-compatible.
-const DEFAULT_MODEL_FALLBACK: &str = "gpt-5.2";
+const DEFAULT_MODEL_FALLBACK: &str = "gpt-5.5";
 
 /// Look up the canonical default model for a target, or [`DEFAULT_MODEL_FALLBACK`].
 fn default_model_for_target(target: &str) -> &'static str {
@@ -978,6 +1193,8 @@ async fn resolve_chat_auth(
         "zai" => "ZAI_API_KEY",
         "deepseek" => "DEEPSEEK_API_KEY",
         "qwen" => "QWEN_API_KEY",
+        "kimi" => "KIMI_API_KEY",
+        "minimax" => "MINIMAX_API_KEY",
         _ => "API_KEY",
     };
     eprintln!("No API key configured for '{target}'. Set {env_var} or add to config.");
@@ -1242,6 +1459,7 @@ fn build_chat_endpoint_and_headers(
 
 async fn cmd_chat(
     model_override: Option<String>,
+    target_override: Option<String>,
     resume: bool,
     session_id: Option<String>,
     coordinator: bool,
@@ -1255,6 +1473,7 @@ async fn cmd_chat(
     // dispatcher, and provider-specific response handlers.
     let Some(repl) = cli::chat_repl::ChatRepl::new(cli::chat_repl::ChatReplArgs {
         model_override,
+        target_override,
         resume,
         session_id,
         coordinator,
@@ -1282,6 +1501,40 @@ mod tests {
     use super::*;
 
     #[test]
+    fn extract_stream_delta_reads_openai_shape() {
+        let json = serde_json::json!({
+            "choices": [{ "delta": { "content": "hello" } }]
+        });
+        assert_eq!(extract_stream_delta(&json), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn extract_stream_delta_reads_anthropic_text_delta() {
+        // The shape /v1/messages streams (including under OAuth Bearer auth).
+        let json = serde_json::json!({
+            "type": "content_block_delta",
+            "delta": { "type": "text_delta", "text": "world" }
+        });
+        assert_eq!(extract_stream_delta(&json), Some("world".to_string()));
+    }
+
+    #[test]
+    fn extract_stream_delta_ignores_non_text_events() {
+        // Anthropic thinking delta carries `delta.thinking`, not `delta.text`.
+        let thinking = serde_json::json!({
+            "type": "content_block_delta",
+            "delta": { "type": "thinking_delta", "thinking": "hmm" }
+        });
+        assert_eq!(extract_stream_delta(&thinking), None);
+        // Stream-lifecycle events have no printable text.
+        let stop = serde_json::json!({ "type": "message_stop" });
+        assert_eq!(extract_stream_delta(&stop), None);
+        // OpenAI role-opener delta (no content field).
+        let opener = serde_json::json!({ "choices": [{ "delta": { "role": "assistant" } }] });
+        assert_eq!(extract_stream_delta(&opener), None);
+    }
+
+    #[test]
     fn resolve_model_prefers_explicit_override() {
         let got = resolve_model_name(
             Some("custom-model".to_string()),
@@ -1301,17 +1554,19 @@ mod tests {
     fn resolve_model_per_target_defaults() {
         assert_eq!(
             resolve_model_name(None, None, "anthropic"),
-            "claude-opus-4-6"
+            "claude-opus-4-8"
         );
-        assert_eq!(resolve_model_name(None, None, "openai"), "gpt-5.2");
-        assert_eq!(resolve_model_name(None, None, "google"), "gemini-2.5-flash");
-        assert_eq!(resolve_model_name(None, None, "zai"), "glm-5");
-        assert_eq!(resolve_model_name(None, None, "deepseek"), "deepseek-chat");
-        assert_eq!(resolve_model_name(None, None, "qwen"), "qwen3.5-plus");
+        assert_eq!(resolve_model_name(None, None, "openai"), "gpt-5.5");
+        assert_eq!(resolve_model_name(None, None, "google"), "gemini-3.1-pro-preview");
+        assert_eq!(resolve_model_name(None, None, "zai"), "glm-5.2");
+        assert_eq!(resolve_model_name(None, None, "deepseek"), "deepseek-v4-pro");
+        assert_eq!(resolve_model_name(None, None, "qwen"), "qwen-3.7-plus");
+        assert_eq!(resolve_model_name(None, None, "kimi"), "kimi-k2.7-code");
+        assert_eq!(resolve_model_name(None, None, "minimax"), "minimax-m3");
         // Unknown target falls back to the OpenAI default.
         assert_eq!(
             resolve_model_name(None, None, "unknown-provider"),
-            "gpt-5.2"
+            "gpt-5.5"
         );
     }
 
@@ -1346,7 +1601,7 @@ mod tests {
             default_model_for_target("definitely-not-a-known-target"),
             DEFAULT_MODEL_FALLBACK
         );
-        assert_eq!(DEFAULT_MODEL_FALLBACK, "gpt-5.2");
+        assert_eq!(DEFAULT_MODEL_FALLBACK, "gpt-5.5");
     }
 
     /// #802 (companion): the table must not contain duplicate target keys —

--- a/src/providers/kimi.rs
+++ b/src/providers/kimi.rs
@@ -1,0 +1,69 @@
+//! Kimi (Moonshot) API adapter (OpenAI-compatible).
+//!
+//! Thin newtype around [`OpenAiCompatibleAdapter`]. Kimi K2.7 is
+//! OpenAI-compatible with standard chat completions.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::config::ThinkingConfig;
+use crate::proxy::ChatCompletionRequest;
+
+use super::openai_compat::{OpenAiCompatibleAdapter, ThinkingInjector};
+use super::{ApiKey, ProviderAdapter, ProviderError};
+
+/// Kimi (Moonshot) API adapter (OpenAI-compatible).
+pub struct KimiAdapter(OpenAiCompatibleAdapter);
+
+impl KimiAdapter {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(OpenAiCompatibleAdapter::new(
+            "kimi",
+            "/v1/chat/completions",
+            ThinkingInjector::OpenAiReasoningEffort,
+            false,
+        ))
+    }
+}
+
+impl Default for KimiAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProviderAdapter for KimiAdapter {
+    fn name(&self) -> &str {
+        self.0.name()
+    }
+
+    fn transform_request(&self, request: &ChatCompletionRequest) -> Result<Value, ProviderError> {
+        self.0.transform_request(request)
+    }
+
+    fn transform_request_with_thinking(
+        &self,
+        request: &ChatCompletionRequest,
+        thinking: &ThinkingConfig,
+    ) -> Result<Value, ProviderError> {
+        self.0.transform_request_with_thinking(request, thinking)
+    }
+
+    fn transform_response(&self, response: Value, stream: bool) -> Result<Value, ProviderError> {
+        self.0.transform_response(response, stream)
+    }
+
+    fn chat_endpoint(&self, model: &str) -> String {
+        self.0.chat_endpoint(model)
+    }
+
+    fn get_headers(&self, api_key: &ApiKey) -> Vec<(String, String)> {
+        self.0.get_headers(api_key)
+    }
+
+    fn supports_model_listing(&self) -> bool {
+        self.0.supports_model_listing()
+    }
+}

--- a/src/providers/minimax.rs
+++ b/src/providers/minimax.rs
@@ -1,0 +1,69 @@
+//! `MiniMax` API adapter (OpenAI-compatible).
+//!
+//! Thin newtype around [`OpenAiCompatibleAdapter`]. `MiniMax` M3 is
+//! OpenAI-compatible with standard chat completions.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::config::ThinkingConfig;
+use crate::proxy::ChatCompletionRequest;
+
+use super::openai_compat::{OpenAiCompatibleAdapter, ThinkingInjector};
+use super::{ApiKey, ProviderAdapter, ProviderError};
+
+/// `MiniMax` API adapter (OpenAI-compatible).
+pub struct MiniMaxAdapter(OpenAiCompatibleAdapter);
+
+impl MiniMaxAdapter {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(OpenAiCompatibleAdapter::new(
+            "minimax",
+            "/v1/chat/completions",
+            ThinkingInjector::OpenAiReasoningEffort,
+            false,
+        ))
+    }
+}
+
+impl Default for MiniMaxAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProviderAdapter for MiniMaxAdapter {
+    fn name(&self) -> &str {
+        self.0.name()
+    }
+
+    fn transform_request(&self, request: &ChatCompletionRequest) -> Result<Value, ProviderError> {
+        self.0.transform_request(request)
+    }
+
+    fn transform_request_with_thinking(
+        &self,
+        request: &ChatCompletionRequest,
+        thinking: &ThinkingConfig,
+    ) -> Result<Value, ProviderError> {
+        self.0.transform_request_with_thinking(request, thinking)
+    }
+
+    fn transform_response(&self, response: Value, stream: bool) -> Result<Value, ProviderError> {
+        self.0.transform_response(response, stream)
+    }
+
+    fn chat_endpoint(&self, model: &str) -> String {
+        self.0.chat_endpoint(model)
+    }
+
+    fn get_headers(&self, api_key: &ApiKey) -> Vec<(String, String)> {
+        self.0.get_headers(api_key)
+    }
+
+    fn supports_model_listing(&self) -> bool {
+        self.0.supports_model_listing()
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -16,6 +16,8 @@ mod anthropic;
 pub mod api_key;
 mod deepseek;
 mod google;
+mod kimi;
+mod minimax;
 mod ollama;
 mod openai;
 mod openai_compat;
@@ -42,6 +44,8 @@ pub use ollama::OllamaAdapter;
 pub use openai::OpenAIAdapter;
 pub use qwen::QwenAdapter;
 pub use zai::ZaiAdapter;
+pub use kimi::KimiAdapter;
+pub use minimax::MiniMaxAdapter;
 
 /// Errors that can occur during provider operations
 #[derive(Error, Debug)]
@@ -253,6 +257,8 @@ pub enum ProviderKind {
     DeepSeek,
     Qwen,
     Zai,
+    Kimi,
+    MiniMax,
     Unknown,
 }
 
@@ -286,6 +292,12 @@ impl ProviderKind {
         if m.starts_with("qwen") || m.starts_with("qwq") || m.starts_with("qvq") {
             return Self::Qwen;
         }
+        if m.starts_with("kimi") {
+            return Self::Kimi;
+        }
+        if m.starts_with("minimax") {
+            return Self::MiniMax;
+        }
         if m.starts_with("glm") {
             return Self::Zai;
         }
@@ -303,6 +315,8 @@ impl ProviderKind {
             Self::DeepSeek => "deepseek",
             Self::Qwen => "qwen",
             Self::Zai => "zai",
+            Self::Kimi => "kimi",
+            Self::MiniMax => "minimax",
             Self::Unknown => "unknown",
         }
     }
@@ -330,6 +344,8 @@ static GOOGLE: GoogleAdapter = GoogleAdapter::new();
 static DEEPSEEK: DeepSeekAdapter = DeepSeekAdapter::new();
 static QWEN: QwenAdapter = QwenAdapter::new();
 static ZAI: ZaiAdapter = ZaiAdapter::new();
+static KIMI: KimiAdapter = KimiAdapter::new();
+static MINIMAX: MiniMaxAdapter = MiniMaxAdapter::new();
 static OLLAMA: OllamaAdapter = OllamaAdapter::new();
 
 /// Canonical names accepted by [`get_adapter`]. Aliases are listed in the
@@ -350,6 +366,8 @@ pub const SUPPORTED_PROVIDERS: &[&str] = &[
     "zai",
     "glm",
     "zhipu",
+    "kimi",
+    "minimax",
     "ollama",
     "local",
     "lmstudio",
@@ -388,6 +406,8 @@ pub fn get_adapter(provider: &str) -> Result<&'static dyn ProviderAdapter, Provi
         "zai" | "glm" | "zhipu" => &ZAI,
         "deepseek" => &DEEPSEEK,
         "qwen" | "alibaba" => &QWEN,
+        "kimi" => &KIMI,
+        "minimax" => &MINIMAX,
         "ollama" => &OLLAMA,
         // OpenAI-compatible providers: explicitly named (no silent fallback
         // for unrecognised names — see the `_ =>` arm below).

--- a/src/tools/bash/mod.rs
+++ b/src/tools/bash/mod.rs
@@ -141,10 +141,7 @@ impl BackgroundShellManager {
 
         #[cfg(windows)]
         let child = {
-            let mut cmd = match find_git_bash() {
-                Some(git_bash) => Command::new(git_bash),
-                None => Command::new("bash"),
-            };
+            let mut cmd = find_git_bash().map_or_else(|| Command::new("bash"), Command::new);
             cmd.args(["-c", command])
                 .current_dir(&cwd)
                 .stdout(Stdio::piped())
@@ -407,7 +404,7 @@ pub static BACKGROUND_SHELLS: std::sync::LazyLock<BackgroundShellManager> =
 
 /// Find Git Bash on Windows
 #[cfg(windows)]
-pub(crate) fn find_git_bash() -> Option<std::path::PathBuf> {
+fn find_git_bash() -> Option<std::path::PathBuf> {
     // Common Git Bash locations on Windows
     let paths = [
         r"C:\Program Files\Git\bin\bash.exe",
@@ -538,10 +535,7 @@ pub fn try_execute_bash(args: &HashMap<String, Value>) -> Result<ToolOutput, Too
 
     #[cfg(windows)]
     let output = {
-        let mut cmd = match find_git_bash() {
-            Some(git_bash) => Command::new(git_bash),
-            None => Command::new("bash"),
-        };
+        let mut cmd = find_git_bash().map_or_else(|| Command::new("bash"), Command::new);
         cmd.args(["-c", command]).current_dir(&cwd);
         apply_env_scrub(&mut cmd);
         cmd.output()

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -23,6 +23,69 @@ use std::time::Duration;
 
 use crate::file_error::{self, FileError};
 
+/// Default model per provider (mirrors `src/main.rs` `DEFAULT_MODELS_BY_TARGET`).
+const DEFAULT_MODELS: &[(&str, &str)] = &[
+    ("anthropic", "claude-opus-4-8"),
+    ("google", "gemini-3.1-pro-preview"),
+    ("openai", "gpt-5.5"),
+    ("deepseek", "deepseek-v4-pro"),
+    ("qwen", "qwen-3.7-plus"),
+    ("zai", "glm-5.2"),
+    ("kimi", "kimi-k2.7-code"),
+    ("minimax", "minimax-m3"),
+];
+
+/// Resolve auth material for a `/provider` switch: `(api_key, oauth_token)`.
+///
+/// For Anthropic with no configured API key, loads Claude Code OAuth
+/// credentials (refreshing if expired) — the same priority as startup's
+/// `resolve_chat_auth`. That load is async, but the TUI runs on a
+/// current-thread tokio runtime that cannot `block_on` reentrantly, so it is
+/// driven on a short-lived helper-thread runtime via [`drive_future_blocking`].
+fn resolve_provider_auth(
+    provider: &str,
+    pconf: &crate::config::ProviderConfig,
+) -> Result<(Option<crate::providers::ApiKey>, Option<String>), String> {
+    if provider == "anthropic" && pconf.api_key.is_none() {
+        if !crate::claude_credentials::has_claude_code_credentials() {
+            return Err(
+                "no ANTHROPIC_API_KEY configured and no Claude Code credentials found".to_string(),
+            );
+        }
+        let creds = drive_future_blocking(crate::claude_credentials::load_credentials())?;
+        return Ok((None, Some(creds.access_token)));
+    }
+    if let Some(key) = &pconf.api_key {
+        return Ok((Some(key.clone()), None));
+    }
+    Err(format!(
+        "no API key configured for '{provider}' (set its api_key or the matching *_API_KEY env var)"
+    ))
+}
+
+/// Drive an async future to completion from a synchronous slash handler.
+///
+/// The TUI event loop runs on a current-thread tokio runtime, so neither
+/// `Handle::block_on` (reentrant panic) nor `block_in_place` (multi-thread
+/// only) is usable here. We offload to a short-lived helper thread with its
+/// own current-thread runtime and join it — the same discipline as
+/// `guardrails::drive_future_sync`'s current-thread branch.
+fn drive_future_blocking<F, T>(fut: F) -> T
+where
+    F: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tui: failed to build helper runtime for provider switch");
+        rt.block_on(fut)
+    })
+    .join()
+    .expect("tui: helper thread panicked during provider-switch auth")
+}
+
 /// Process-wide shutdown flag for the TUI event loop.
 ///
 /// crosslink #910: the original `run()` loop relied entirely on the
@@ -1783,6 +1846,11 @@ impl App {
     /// branches into the table; each is a 3-line entry once a sibling
     /// helper exists.
     fn handle_slash_command(&mut self, text: &str) -> bool {
+        // /provider <name> — switch provider + default model (prefix dispatch, takes arg)
+        if text.starts_with("/provider") {
+            self.slash_provider(text);
+            return true;
+        }
         if let Some(handler) = lookup_tui_slash(text) {
             handler(self);
             return true;
@@ -1867,6 +1935,90 @@ impl App {
             self.messages
                 .add(DisplayMessage::system(format!("Available skills:\n{list}")));
         }
+    }
+
+    /// Table-handler entry point for `/provider`.
+    ///
+    /// Switches the live provider/model AND re-resolves the transport
+    /// (endpoint + auth headers + OAuth token) so subsequent turns actually
+    /// reach the new provider. Updating the labels alone left requests
+    /// pointed at the previous provider's endpoint and key.
+    fn slash_provider(&mut self, text: &str) {
+        let name = text
+            .strip_prefix("/provider ")
+            .or_else(|| text.strip_prefix("/provider"))
+            .unwrap_or("")
+            .trim();
+        if name.is_empty() || name == "list" {
+            let providers: Vec<&str> = DEFAULT_MODELS.iter().map(|(p, _)| *p).collect();
+            self.messages.add(DisplayMessage::system(format!(
+                "Available providers: {}\nUsage: /provider <name>",
+                providers.join(", ")
+            )));
+            return;
+        }
+        let Some(&(_, default_model)) = DEFAULT_MODELS.iter().find(|(p, _)| *p == name) else {
+            self.messages.add(DisplayMessage::system(format!(
+                "Unknown provider: {name}. Use /provider list"
+            )));
+            return;
+        };
+        match self.reconfigure_provider(name, default_model) {
+            Ok(()) => self.messages.add(DisplayMessage::system(format!(
+                "Switched to {name} (model: {default_model})"
+            ))),
+            Err(e) => self.messages.add(DisplayMessage::system(format!(
+                "Cannot switch to {name}: {e}"
+            ))),
+        }
+    }
+
+    /// Re-resolve the endpoint, auth, and headers for `provider` and rewire
+    /// the live [`ApiClient`] so the next turn targets the new provider.
+    ///
+    /// Mirrors the startup auth resolution (`resolve_chat_auth` +
+    /// [`crate::pipeline::resolve_endpoint`] / [`crate::pipeline::resolve_headers`])
+    /// but lives in the lib so the TUI can switch providers mid-session.
+    /// Returns `Err` *without* mutating any state when the new provider has
+    /// no usable credentials, so the session stays on its working provider.
+    fn reconfigure_provider(&mut self, provider: &str, model: &str) -> Result<(), String> {
+        let config =
+            crate::config::load_config().map_err(|e| format!("config load failed: {e}"))?;
+        let pconf = config
+            .get_provider(provider)
+            .ok_or_else(|| format!("no configuration for provider '{provider}'"))?;
+
+        let (api_key, claude_code_token) = resolve_provider_auth(provider, pconf)?;
+
+        let extra_headers: Vec<(String, String)> = pconf
+            .headers
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let endpoint = crate::pipeline::resolve_endpoint(
+            provider,
+            model,
+            &pconf.base_url,
+            claude_code_token.as_deref(),
+        )
+        .map_err(|e| format!("endpoint resolution failed: {e}"))?;
+        let headers = crate::pipeline::resolve_headers(
+            provider,
+            api_key.as_ref(),
+            claude_code_token.as_deref(),
+            &extra_headers,
+        )
+        .map_err(|e| format!("header resolution failed: {e}"))?;
+
+        // Commit only after every fallible step succeeded.
+        self.provider = provider.to_string();
+        self.chat_session.provider.clone_from(&self.provider);
+        self.model = model.to_string();
+        self.chat_session.model.clone_from(&self.model);
+        self.api_client.endpoint = endpoint;
+        self.api_client.headers = headers;
+        self.api_client.claude_code_token = claude_code_token;
+        Ok(())
     }
 
     /// Handle skill invocations and info/diagnostic commands.


### PR DESCRIPTION
## Summary
- `openclaudia auth` now writes the standard Claude Code credential store (`~/.claude/.credentials.json`), so chat/proxy/TUI work on a Claude subscription without Claude Code installed. Uses atomic temp-file + rename, advisory locking (`flock` on Unix, `LockFileEx` on Windows), and honors `CLAUDE_CONFIG_DIR`.
- `auth --status` reports the chat-usable credential store via `peek_credentials()`.
- Adds Kimi and MiniMax OpenAI-compatible providers (config defaults, init template, model lists, `KIMI_API_KEY` / `MINIMAX_API_KEY` env vars).
- TUI `/provider` re-resolves endpoint, headers, and OAuth tokens mid-session instead of only updating labels.
- Bumps default model strings and improves `-p` print-mode extraction for Anthropic non-streaming content blocks.

## Test plan
- [ ] `cargo build` and `cargo test --bin openclaudia` pass
- [ ] `openclaudia auth` writes `~/.claude/.credentials.json` with `claudeAiOauth`
- [ ] `openclaudia auth --status` shows valid credentials and inference scope
- [ ] Chat/TUI works with OAuth (no `ANTHROPIC_API_KEY`) after auth
- [ ] TUI `/provider` switches live API client, not just status text
- [ ] Kimi/MiniMax targets resolve with configured API keys
- [ ] On Windows: concurrent credential refresh does not corrupt `.credentials.json`