### PR TITLE
Fix macOS build: portable errno access in terminate_process_tree

### DIFF
--- a/src/tools/bash/kill.rs
+++ b/src/tools/bash/kill.rs
@@ -80,7 +80,7 @@ pub fn terminate_process_tree(pid: u32) {
         if sigterm_result != 0 {
             tracing::debug!(
                 pid,
-                errno = unsafe { *libc::__errno_location() },
+                errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
                 "terminate_process_tree: SIGTERM to process group failed"
             );
         }
@@ -109,7 +109,7 @@ pub fn terminate_process_tree(pid: u32) {
             if sigkill_result != 0 {
                 tracing::debug!(
                     pid,
-                    errno = unsafe { *libc::__errno_location() },
+                    errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
                     "terminate_process_tree: SIGKILL to process group failed"
                 );
             }


### PR DESCRIPTION
## Problem

The crate fails to compile on macOS (and any non-glibc target):

```
error[E0425]: cannot find function `__errno_location` in crate `libc`
  --> src/tools/bash/kill.rs:83:41
```

`terminate_process_tree()` logs `errno` via `libc::__errno_location()`, which is a
**glibc-only** symbol. On macOS the errno accessor is `__error()`, on other libcs it
differs again, so the build breaks outside Linux/glibc. This affects the tagged
`v0.5.0` release as well as `main`.

## Fix

Replace both call sites with the portable standard-library accessor:

```rust
errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
```

`std::io::Error::last_os_error()` reads the same thread-local `errno` on every Unix
target, so behaviour on Linux is unchanged and macOS now compiles. The value is only
used in a `tracing::debug!` log.

This also aligns with the existing convention already used elsewhere in the codebase
(`src/oauth.rs` and `src/cli/commands/auth.rs` compare errno via
`err.raw_os_error() == Some(libc::ELOOP)`).

## Verification

- `cargo build --release` succeeds on macOS (Darwin) where it previously failed.
- Empirically confirmed equivalence on macOS: after a failing `kill(2)`, both
  `*libc::__error()` (the real macOS errno location) and
  `std::io::Error::last_os_error().raw_os_error()` report the same value (`ESRCH = 3`).
- Existing `terminate_process_tree` unit test passes; no new clippy warnings in the file.
- Audited every other `libc::` use in `src/` — all are POSIX/BSD symbols present on
  macOS (`kill`, `flock`, `getuid`, `umask`, `O_NOFOLLOW`, `ELOOP`); `__errno_location`
  was the only non-portable one.
