### PR TITLE
[codex] fix repo-wide lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ providers:
     # api_key: ${OPENCODE_API_KEY}
   # Generic OpenAI-compatible endpoint
   openai-compatible:
-    base_url: https://api.example.com/v1
+    base_url: https://example.com/v1
     # api_key: ${OPENAI_COMPATIBLE_API_KEY}
     # model: my-model-name
   # Ollama for local LLM inference

--- a/src/cli/chat_repl.rs
+++ b/src/cli/chat_repl.rs
@@ -379,6 +379,30 @@ fn apply_model_provider_override(config: &mut config::AppConfig, model: &str) {
     }
 }
 
+async fn resolve_repl_chat_auth(
+    config: &config::AppConfig,
+    provider: &config::ProviderConfig,
+) -> anyhow::Result<ChatAuth> {
+    let Some(auth) = resolve_chat_auth(
+        &config.proxy.target,
+        provider,
+        ChatAuthSelectionMode::Automatic,
+    )
+    .await?
+    else {
+        anyhow::bail!(
+            "could not resolve authentication for target '{}'",
+            config.proxy.target
+        );
+    };
+    if auth.codex_responses_auth.is_some() {
+        anyhow::bail!(
+            "Codex ChatGPT login currently requires the full-screen TUI Responses backend"
+        );
+    }
+    Ok(auth)
+}
+
 impl ChatRepl {
     /// Resolve config + auth + provider + session and return a fully
     /// initialized REPL. Setup failures return an error after printing the
@@ -421,27 +445,11 @@ impl ChatRepl {
             }
         };
 
-        let Some(ChatAuth {
+        let ChatAuth {
             api_key,
             claude_code_token,
-            codex_responses_auth,
-        }) = resolve_chat_auth(
-            &config.proxy.target,
-            provider,
-            ChatAuthSelectionMode::Automatic,
-        )
-        .await?
-        else {
-            anyhow::bail!(
-                "could not resolve authentication for target '{}'",
-                config.proxy.target
-            );
-        };
-        if codex_responses_auth.is_some() {
-            anyhow::bail!(
-                "Codex ChatGPT login currently requires the full-screen TUI Responses backend"
-            );
-        }
+            codex_responses_auth: _,
+        } = resolve_repl_chat_auth(&config, provider).await?;
 
         let model = resolve_model_name(
             args.model_override,
@@ -4281,7 +4289,7 @@ providers: {}
         let mut ledger = openclaudia::ledger::RealityLedger::new();
         let content = "Verified with cargo test.";
 
-        openclaudia::grounded_loop::validate_final_against_ledger(&mut ledger, &content)
+        openclaudia::grounded_loop::validate_final_against_ledger(&mut ledger, content)
             .expect("plain assistant text should render");
 
         assert!(ledger

--- a/src/codex_credentials.rs
+++ b/src/codex_credentials.rs
@@ -1,9 +1,9 @@
-//! Codex credential discovery for OpenAI auth.
+//! Codex credential discovery for `OpenAI` auth.
 //!
 //! Codex stores login material in `$CODEX_HOME/auth.json` (or
 //! `~/.codex/auth.json`) with the same logical shape as its open-source Rust
 //! client. We read only enough of that shape to reuse supported credentials:
-//! OpenAI API keys can feed the existing Chat Completions path, while ChatGPT
+//! `OpenAI` API keys can feed the existing Chat Completions path, while `ChatGPT`
 //! and Codex personal access tokens must use the Responses backend.
 
 use base64::Engine as _;
@@ -198,7 +198,7 @@ fn trimmed_nonempty(value: Option<String>) -> Option<String> {
     })
 }
 
-fn raw_id_token(id_token: &Option<IdToken>) -> Option<&str> {
+fn raw_id_token(id_token: Option<&IdToken>) -> Option<&str> {
     match id_token {
         Some(IdToken::Raw(raw)) => Some(raw.as_str()),
         Some(IdToken::Object { raw_jwt, .. }) => raw_jwt.as_deref(),
@@ -206,7 +206,7 @@ fn raw_id_token(id_token: &Option<IdToken>) -> Option<&str> {
     }
 }
 
-fn id_token_claims(id_token: &Option<IdToken>) -> JwtClaims {
+fn id_token_claims(id_token: Option<&IdToken>) -> JwtClaims {
     let mut claims = raw_id_token(id_token)
         .and_then(parse_jwt_claims)
         .unwrap_or_default();
@@ -282,40 +282,38 @@ fn resolved_mode(auth: &AuthDotJson) -> Option<CodexAuthMode> {
     None
 }
 
-fn load_from_auth_json(auth: AuthDotJson) -> Result<Option<CodexAuthMaterial>, String> {
-    let Some(mode) = resolved_mode(&auth) else {
-        return Ok(None);
-    };
+fn load_from_auth_json(auth: AuthDotJson) -> Option<CodexAuthMaterial> {
+    let mode = resolved_mode(&auth)?;
     match mode {
         CodexAuthMode::ApiKey => {
             let Some(api_key) = trimmed_nonempty(auth.openai_api_key) else {
-                return Ok(Some(CodexAuthMaterial::Unsupported {
+                return Some(CodexAuthMaterial::Unsupported {
                     mode,
                     source: CodexAuthSource::AuthJson,
-                }));
+                });
             };
-            Ok(Some(CodexAuthMaterial::ApiKey {
+            Some(CodexAuthMaterial::ApiKey {
                 api_key,
                 source: CodexAuthSource::AuthJson,
-            }))
+            })
         }
         CodexAuthMode::Chatgpt | CodexAuthMode::ChatgptAuthTokens => {
             let Some(tokens) = auth.tokens else {
-                return Ok(Some(CodexAuthMaterial::Unsupported {
+                return Some(CodexAuthMaterial::Unsupported {
                     mode,
                     source: CodexAuthSource::AuthJson,
-                }));
+                });
             };
             let access_token = tokens.access_token.trim().to_string();
             if access_token.is_empty() {
-                return Ok(Some(CodexAuthMaterial::Unsupported {
+                return Some(CodexAuthMaterial::Unsupported {
                     mode,
                     source: CodexAuthSource::AuthJson,
-                }));
+                });
             }
-            let claims = id_token_claims(&tokens.id_token);
+            let claims = id_token_claims(tokens.id_token.as_ref());
             let token_claims = parse_jwt_claims(&access_token).unwrap_or_default();
-            Ok(Some(CodexAuthMaterial::Responses(CodexResponsesAuth {
+            Some(CodexAuthMaterial::Responses(CodexResponsesAuth {
                 access_token,
                 account_id: tokens
                     .account_id
@@ -324,29 +322,29 @@ fn load_from_auth_json(auth: AuthDotJson) -> Result<Option<CodexAuthMaterial>, S
                 is_fedramp_account: claims.is_fedramp_account || token_claims.is_fedramp_account,
                 source: CodexAuthSource::AuthJson,
                 mode,
-            })))
+            }))
         }
         CodexAuthMode::PersonalAccessToken => {
             let Some(access_token) = trimmed_nonempty(auth.personal_access_token) else {
-                return Ok(Some(CodexAuthMaterial::Unsupported {
+                return Some(CodexAuthMaterial::Unsupported {
                     mode,
                     source: CodexAuthSource::AuthJson,
-                }));
+                });
             };
             let claims = parse_jwt_claims(&access_token).unwrap_or_default();
-            Ok(Some(CodexAuthMaterial::Responses(CodexResponsesAuth {
+            Some(CodexAuthMaterial::Responses(CodexResponsesAuth {
                 access_token,
                 account_id: claims.account_id,
                 is_fedramp_account: claims.is_fedramp_account,
                 source: CodexAuthSource::AuthJson,
                 mode,
-            })))
+            }))
         }
         CodexAuthMode::AgentIdentity | CodexAuthMode::BedrockApiKey => {
-            Ok(Some(CodexAuthMaterial::Unsupported {
+            Some(CodexAuthMaterial::Unsupported {
                 mode,
                 source: CodexAuthSource::AuthJson,
-            }))
+            })
         }
     }
 }
@@ -373,6 +371,11 @@ pub fn has_codex_auth_json() -> bool {
 ///
 /// This intentionally does not inspect OS keyrings or refresh tokens; those are
 /// owned by Codex proper. Stale cached tokens surface as upstream auth errors.
+///
+/// # Errors
+///
+/// Returns an error if auth.json exists but cannot be read, is symlinked, or
+/// cannot be parsed as Codex auth material.
 pub fn load_codex_auth() -> Result<Option<CodexAuthMaterial>, String> {
     if let Ok(token) = std::env::var(CODEX_ACCESS_TOKEN_ENV_VAR) {
         let token = token.trim();
@@ -394,6 +397,12 @@ pub fn load_codex_auth() -> Result<Option<CodexAuthMaterial>, String> {
     load_codex_auth_from_path(&path)
 }
 
+/// Load Codex auth material from a specific auth.json path.
+///
+/// # Errors
+///
+/// Returns an error if `path` is a symlink, cannot be read, or does not contain
+/// valid JSON in the expected auth.json shape.
 pub fn load_codex_auth_from_path(path: &Path) -> Result<Option<CodexAuthMaterial>, String> {
     let metadata = match std::fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
@@ -407,7 +416,7 @@ pub fn load_codex_auth_from_path(path: &Path) -> Result<Option<CodexAuthMaterial
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
     let auth: AuthDotJson = serde_json::from_str(&raw)
         .map_err(|err| format!("failed to parse {}: {err}", path.display()))?;
-    load_from_auth_json(auth)
+    Ok(load_from_auth_json(auth))
 }
 
 #[cfg(test)]
@@ -415,16 +424,16 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn write_auth_json(value: Value) -> (tempfile::TempDir, PathBuf) {
+    fn write_auth_json(value: &Value) -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("auth.json");
-        std::fs::write(&path, serde_json::to_vec(&value).expect("json")).expect("write auth");
+        std::fs::write(&path, serde_json::to_vec(value).expect("json")).expect("write auth");
         (dir, path)
     }
 
     #[test]
     fn loads_api_key_from_auth_json() {
-        let (_dir, path) = write_auth_json(json!({
+        let (_dir, path) = write_auth_json(&json!({
             "auth_mode": "api_key",
             "OPENAI_API_KEY": "sk-test"
         }));
@@ -444,7 +453,7 @@ mod tests {
 
     #[test]
     fn loads_chatgpt_tokens_for_responses_backend() {
-        let (_dir, path) = write_auth_json(json!({
+        let (_dir, path) = write_auth_json(&json!({
             "auth_mode": "chatgpt",
             "tokens": {
                 "access_token": "access-token",

--- a/src/grounded_loop.rs
+++ b/src/grounded_loop.rs
@@ -462,7 +462,7 @@ pub fn validate_and_render_final_against_ledger(
     content: &str,
 ) -> Result<String, String> {
     match parse_structured_final_decision(content) {
-        Ok(Some(decision)) => return validate_and_render_structured_final(ledger, decision),
+        Ok(Some(decision)) => return validate_and_render_structured_final(ledger, &decision),
         Ok(None) => {}
         Err(reason) => {
             append_final_policy_decision(ledger, false, &reason);
@@ -476,21 +476,18 @@ pub fn validate_and_render_final_against_ledger(
 
 fn validate_and_render_structured_final(
     ledger: &mut RealityLedger,
-    decision: crate::decision::AgentDecision,
+    decision: &crate::decision::AgentDecision,
 ) -> Result<String, String> {
-    let summary = match &decision {
-        crate::decision::AgentDecision::Final { summary, .. } => summary.clone(),
-        _ => {
-            let reason = "structured final decision must have kind 'final'".to_string();
-            append_final_policy_decision(ledger, false, &reason);
-            return Err(reason);
-        }
+    let crate::decision::AgentDecision::Final { summary, .. } = decision else {
+        let reason = "structured final decision must have kind 'final'".to_string();
+        append_final_policy_decision(ledger, false, &reason);
+        return Err(reason);
     };
 
-    match crate::decision::validate_decision(&decision, ledger) {
+    match crate::decision::validate_decision(decision, ledger) {
         Ok(crate::decision::DecisionValidation::Final(_)) => {
             append_final_policy_decision(ledger, true, "structured final decision grounded");
-            Ok(summary)
+            Ok(summary.clone())
         }
         Ok(_) => {
             let reason = "structured final decision validated as a non-final decision".to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,17 +57,14 @@ fn open_tui_log_file(dir: &Path, pid: u32) -> Option<std::fs::File> {
     }
 
     let path = dir.join(format!("tui-{pid}.log"));
-    match std::fs::OpenOptions::new()
+    std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
-    {
-        Ok(file) => Some(file),
-        Err(_) => None,
-    }
+        .ok()
 }
 
-fn should_redirect_tui_logs(cli: &Cli) -> bool {
+const fn should_redirect_tui_logs(cli: &Cli) -> bool {
     cli.command.is_none() && !cli.tui_mode && cli.print.is_none()
 }
 
@@ -422,20 +419,13 @@ struct TuiStartupOptions {
     mode_arg: Option<String>,
 }
 
-async fn cmd_tui(options: TuiStartupOptions) -> anyhow::Result<()> {
-    chdir_to_git_root();
+struct PreparedTuiStartup {
+    config: config::AppConfig,
+    startup_auth: Option<TuiStartupSelections>,
+    vdd_adversary_auth: Option<openclaudia::vdd::VddProviderAuth>,
+}
 
-    let behavior_mode =
-        parse_initial_behavior_mode(options.mode_arg.as_deref()).map_err(|e| anyhow::anyhow!(e))?;
-
-    // Crosslink #797: every configuration-load / provider-resolve /
-    // auth-resolve failure path used to print to stderr and return
-    // `Ok(())`, giving exit code 0 even on a broken setup. `set -e`
-    // wrappers and orchestration that branches on exit status saw success
-    // and continued. Each failure now propagates as `anyhow::Error` so
-    // main() exits non-zero; the human-readable `eprintln!` messages stay
-    // for friendly framing, but the error-vs-non-error distinction is no
-    // longer collapsed at the exit boundary.
+async fn prepare_tui_startup(options: &TuiStartupOptions) -> anyhow::Result<PreparedTuiStartup> {
     let mut config = config::load_config().map_err(|e| {
         if config::config_file_exists() {
             eprintln!("Failed to parse configuration: {e}");
@@ -446,7 +436,7 @@ async fn cmd_tui(options: TuiStartupOptions) -> anyhow::Result<()> {
         }
     })?;
 
-    let startup_auth = if should_prompt_tui_startup_auth(&options) {
+    let startup_auth = if should_prompt_tui_startup_auth(options) {
         select_tui_startup_auth(&config).await?
     } else {
         None
@@ -477,7 +467,11 @@ async fn cmd_tui(options: TuiStartupOptions) -> anyhow::Result<()> {
                     .adversary
                     .provider
                     .clone_from(&vdd_selection.target);
-                config.vdd.adversary.api_key = vdd_selection.auth.api_key.clone();
+                config
+                    .vdd
+                    .adversary
+                    .api_key
+                    .clone_from(&vdd_selection.auth.api_key);
                 Some(vdd_selection.auth.to_vdd_provider_auth())
             }
         });
@@ -486,6 +480,25 @@ async fn cmd_tui(options: TuiStartupOptions) -> anyhow::Result<()> {
         .vdd
         .validate(&config.proxy.target)
         .map_err(|e| anyhow::anyhow!("VDD configuration error: {e}"))?;
+
+    Ok(PreparedTuiStartup {
+        config,
+        startup_auth,
+        vdd_adversary_auth,
+    })
+}
+
+async fn cmd_tui(options: TuiStartupOptions) -> anyhow::Result<()> {
+    chdir_to_git_root();
+
+    let behavior_mode =
+        parse_initial_behavior_mode(options.mode_arg.as_deref()).map_err(|e| anyhow::anyhow!(e))?;
+
+    let PreparedTuiStartup {
+        config,
+        startup_auth,
+        vdd_adversary_auth,
+    } = prepare_tui_startup(&options).await?;
 
     let Some(provider) = config.active_provider() else {
         eprintln!(
@@ -1220,20 +1233,25 @@ struct ChatAuth {
     /// `~/.claude/.credentials.json` store.
     claude_code_token: Option<String>,
     /// Codex ChatGPT/PAT bearer auth. This must be sent to the Codex
-    /// Responses backend, not OpenAI Chat Completions.
+    /// Responses backend, not `OpenAI` Chat Completions.
     codex_responses_auth: Option<openclaudia::codex_credentials::CodexResponsesAuth>,
 }
 
 impl ChatAuth {
     fn to_vdd_provider_auth(&self) -> openclaudia::vdd::VddProviderAuth {
-        if let Some(auth) = &self.codex_responses_auth {
-            openclaudia::vdd::VddProviderAuth::codex_responses(auth.clone())
-        } else if let Some(token) = &self.claude_code_token {
-            openclaudia::vdd::VddProviderAuth::claude_code_token(token.clone())
-        } else if let Some(api_key) = &self.api_key {
-            openclaudia::vdd::VddProviderAuth::api_key(api_key.clone())
-        } else {
-            openclaudia::vdd::VddProviderAuth::None
+        match (
+            self.codex_responses_auth.as_ref(),
+            self.claude_code_token.as_ref(),
+            self.api_key.as_ref(),
+        ) {
+            (Some(auth), _, _) => openclaudia::vdd::VddProviderAuth::codex_responses(auth.clone()),
+            (None, Some(token), _) => {
+                openclaudia::vdd::VddProviderAuth::claude_code_token(token.clone())
+            }
+            (None, None, Some(api_key)) => {
+                openclaudia::vdd::VddProviderAuth::api_key(api_key.clone())
+            }
+            (None, None, None) => openclaudia::vdd::VddProviderAuth::None,
         }
     }
 }
@@ -1517,7 +1535,7 @@ fn select_openai_auth_candidate(
     Ok(auth)
 }
 
-fn should_prompt_tui_startup_auth(options: &TuiStartupOptions) -> bool {
+const fn should_prompt_tui_startup_auth(options: &TuiStartupOptions) -> bool {
     options.target_override.is_none() && options.model_override.is_none()
 }
 
@@ -1586,21 +1604,16 @@ fn collect_openai_startup_auth_candidates(
 
 fn canonical_startup_provider(provider: &str) -> &str {
     match provider.trim().to_ascii_lowercase().as_str() {
-        "gemini" => "google",
-        "alibaba" => "qwen",
-        "zhipu" | "glm" => "zai",
-        "moonshot" => "kimi",
-        "lmstudio" | "localai" | "text-generation-webui" => "local",
+        "gemini" | "google" => "google",
+        "alibaba" | "qwen" => "qwen",
+        "zhipu" | "glm" | "zai" => "zai",
+        "moonshot" | "kimi" => "kimi",
+        "lmstudio" | "localai" | "text-generation-webui" | "local" => "local",
         "anthropic" => "anthropic",
         "openai" => "openai",
-        "google" => "google",
-        "qwen" => "qwen",
-        "zai" => "zai",
-        "kimi" => "kimi",
         "deepseek" => "deepseek",
         "minimax" => "minimax",
         "ollama" => "ollama",
-        "local" => "local",
         _ => provider.trim(),
     }
 }
@@ -1730,13 +1743,13 @@ fn collect_tui_startup_vdd_auth_candidates(
 
     collect_configured_provider_api_key_candidates(config, &mut candidates, Some(chat_target));
 
-    if !same_startup_provider("anthropic", chat_target) {
-        if openclaudia::claude_credentials::has_claude_code_credentials() {
-            push_unique_startup_candidate(
-                &mut candidates,
-                TuiStartupAuthCandidate::AnthropicClaudeCode,
-            );
-        }
+    if !same_startup_provider("anthropic", chat_target)
+        && openclaudia::claude_credentials::has_claude_code_credentials()
+    {
+        push_unique_startup_candidate(
+            &mut candidates,
+            TuiStartupAuthCandidate::AnthropicClaudeCode,
+        );
     }
 
     if !same_startup_provider("openai", chat_target) {
@@ -1921,6 +1934,79 @@ async fn resolve_tui_chat_auth(
     resolve_chat_auth(target, provider, ChatAuthSelectionMode::Interactive).await
 }
 
+fn select_openai_auth_if_available(
+    candidates: Vec<OpenAiAuthCandidate>,
+    selection_mode: ChatAuthSelectionMode,
+) -> anyhow::Result<Option<ChatAuth>> {
+    if selection_mode == ChatAuthSelectionMode::Interactive || !candidates.is_empty() {
+        return Ok(Some(select_openai_auth_candidate(
+            candidates,
+            selection_mode,
+        )?));
+    }
+    Ok(None)
+}
+
+fn resolve_openai_chat_auth(
+    target: &str,
+    provider: &openclaudia::config::ProviderConfig,
+    selection_mode: ChatAuthSelectionMode,
+) -> anyhow::Result<Option<ChatAuth>> {
+    let mut candidates = Vec::new();
+    if let Some(k) = &provider.api_key {
+        candidates.push(OpenAiAuthCandidate::ApiKey {
+            api_key: k.clone(),
+            label: "configured OpenAI API key".to_string(),
+        });
+    }
+
+    match openclaudia::codex_credentials::load_codex_auth() {
+        Ok(Some(openclaudia::codex_credentials::CodexAuthMaterial::ApiKey { api_key, source })) => {
+            let api_key = openclaudia::providers::ApiKey::try_from_string(api_key)
+                .map_err(|e| anyhow::anyhow!("Codex OpenAI API key is invalid: {e}"))?;
+            candidates.push(OpenAiAuthCandidate::ApiKey {
+                api_key,
+                label: format!("OpenAI API key via {}", source.display_name()),
+            });
+        }
+        Ok(Some(openclaudia::codex_credentials::CodexAuthMaterial::Responses(auth))) => {
+            candidates.push(OpenAiAuthCandidate::CodexResponses(auth));
+        }
+        Ok(Some(openclaudia::codex_credentials::CodexAuthMaterial::Unsupported {
+            mode,
+            source,
+        })) => {
+            if let Some(auth) = select_openai_auth_if_available(candidates, selection_mode)? {
+                return Ok(Some(auth));
+            }
+            eprintln!(
+                "Codex auth found via {}, but {} is not usable for OpenAI Responses in OpenClaudia.",
+                source.display_name(),
+                mode.display_name()
+            );
+            eprintln!("Set OPENAI_API_KEY, or log in to Codex with ChatGPT/PAT auth.");
+            return Ok(None);
+        }
+        Ok(None) => {}
+        Err(e) => {
+            if let Some(auth) = select_openai_auth_if_available(candidates, selection_mode)? {
+                return Ok(Some(auth));
+            }
+            eprintln!("Error: Codex credentials unusable: {e}");
+            eprintln!("Set OPENAI_API_KEY, or run `codex login`.");
+            return Ok(None);
+        }
+    }
+
+    if let Some(auth) = select_openai_auth_if_available(candidates, selection_mode)? {
+        return Ok(Some(auth));
+    }
+
+    let env_var = openclaudia::providers::api_key_env_var_for_target(target);
+    eprintln!("No API key configured for '{target}'. Set {env_var} or add to config.");
+    Ok(None)
+}
+
 /// Resolve which authentication mechanism the chat session should use.
 ///
 /// Priority for Anthropic:
@@ -1969,74 +2055,7 @@ async fn resolve_chat_auth(
     }
 
     if target.eq_ignore_ascii_case("openai") {
-        let mut candidates = Vec::new();
-        if let Some(k) = &provider.api_key {
-            candidates.push(OpenAiAuthCandidate::ApiKey {
-                api_key: k.clone(),
-                label: "configured OpenAI API key".to_string(),
-            });
-        }
-
-        match openclaudia::codex_credentials::load_codex_auth() {
-            Ok(Some(openclaudia::codex_credentials::CodexAuthMaterial::ApiKey {
-                api_key,
-                source,
-            })) => {
-                let api_key = openclaudia::providers::ApiKey::try_from_string(api_key)
-                    .map_err(|e| anyhow::anyhow!("Codex OpenAI API key is invalid: {e}"))?;
-                candidates.push(OpenAiAuthCandidate::ApiKey {
-                    api_key,
-                    label: format!("OpenAI API key via {}", source.display_name()),
-                });
-            }
-            Ok(Some(openclaudia::codex_credentials::CodexAuthMaterial::Responses(auth))) => {
-                candidates.push(OpenAiAuthCandidate::CodexResponses(auth));
-            }
-            Ok(Some(openclaudia::codex_credentials::CodexAuthMaterial::Unsupported {
-                mode,
-                source,
-            })) => {
-                if selection_mode == ChatAuthSelectionMode::Interactive || !candidates.is_empty() {
-                    return Ok(Some(select_openai_auth_candidate(
-                        candidates,
-                        selection_mode,
-                    )?));
-                }
-                eprintln!(
-                    "Codex auth found via {}, but {} is not usable for OpenAI Responses in OpenClaudia.",
-                    source.display_name(),
-                    mode.display_name()
-                );
-                eprintln!("Set OPENAI_API_KEY, or log in to Codex with ChatGPT/PAT auth.");
-                return Ok(None);
-            }
-            Ok(None) => {
-                if selection_mode == ChatAuthSelectionMode::Interactive || !candidates.is_empty() {
-                    return Ok(Some(select_openai_auth_candidate(
-                        candidates,
-                        selection_mode,
-                    )?));
-                }
-            }
-            Err(e) => {
-                if selection_mode == ChatAuthSelectionMode::Interactive || !candidates.is_empty() {
-                    return Ok(Some(select_openai_auth_candidate(
-                        candidates,
-                        selection_mode,
-                    )?));
-                }
-                eprintln!("Error: Codex credentials unusable: {e}");
-                eprintln!("Set OPENAI_API_KEY, or run `codex login`.");
-                return Ok(None);
-            }
-        }
-
-        if selection_mode == ChatAuthSelectionMode::Interactive || !candidates.is_empty() {
-            return Ok(Some(select_openai_auth_candidate(
-                candidates,
-                selection_mode,
-            )?));
-        }
+        return resolve_openai_chat_auth(target, provider, selection_mode);
     }
 
     if let Some(k) = &provider.api_key {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -79,10 +79,10 @@ pub struct TurnResult {
 /// Wire protocol used for the outbound provider request.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum WireApi {
-    /// OpenAI-compatible Chat Completions (`messages`, `choices[].delta`).
+    /// `OpenAI`-compatible Chat Completions (`messages`, `choices[].delta`).
     #[default]
     ChatCompletions,
-    /// OpenAI Responses (`input`, `response.output_text.delta`, response items).
+    /// `OpenAI` Responses (`input`, `response.output_text.delta`, response items).
     OpenAiResponses,
 }
 
@@ -223,7 +223,7 @@ fn text_from_message_content(content: &Value) -> Result<String, String> {
     Ok(text)
 }
 
-fn response_input_message(role: &str, text: String) -> Value {
+fn response_input_message(role: &str, text: &str) -> Value {
     let item_type = if role == "assistant" {
         "output_text"
     } else {
@@ -252,10 +252,10 @@ fn responses_input_items(messages: &[Value]) -> Result<(String, Vec<Value>), Str
                     instructions.push(content);
                 }
             }
-            "user" => input.push(response_input_message("user", content)),
+            "user" => input.push(response_input_message("user", &content)),
             "assistant" => {
                 if !content.is_empty() {
-                    input.push(response_input_message("assistant", content));
+                    input.push(response_input_message("assistant", &content));
                 }
                 if let Some(tool_calls) = msg.get("tool_calls").and_then(Value::as_array) {
                     for call in tool_calls {
@@ -361,7 +361,7 @@ fn responses_reasoning(effort_level: &str) -> Option<Value> {
     }
 }
 
-/// Build an OpenAI Responses API request body.
+/// Build an `OpenAI` Responses API request body.
 ///
 /// # Errors
 ///
@@ -395,6 +395,11 @@ pub fn build_openai_responses_request(
 
 /// Build the canonical chat-completions request used for policy accounting
 /// before provider-specific adapter transformation.
+///
+/// # Errors
+///
+/// Returns an error if a session message cannot be converted into a typed chat
+/// message or if the built-in tool definitions are not represented as an array.
 pub fn build_chat_completion_request(
     model: &str,
     messages: &[Value],
@@ -1925,31 +1930,7 @@ async fn stream_responses_sse_response(p: SseStreamParams<'_>) -> Result<TurnRes
             tx,
         )?;
         if done {
-            let (tool_results, needs_followup) = execute_tool_calls_for_tui(
-                &tool_calls,
-                memory_db.clone(),
-                app_config.clone(),
-                permission_mgr.clone(),
-                transient_allowed_tool_rules,
-                hook_engine.clone(),
-                policy_enforcer.clone(),
-                task_mgr.clone(),
-                session_id.as_deref(),
-                tx,
-            )
-            .await;
-            if !needs_followup {
-                send_event!(tx, AppEvent::ResponseDone);
-            }
-            return Ok(TurnResult {
-                content: full_content,
-                reasoning_content: (!reasoning_content.is_empty()).then_some(reasoning_content),
-                tool_calls,
-                tool_results,
-                usage: stream_usage,
-                needs_followup,
-                finish_reason: None,
-            });
+            break;
         }
     }
 
@@ -2354,20 +2335,33 @@ struct ToolPermissionDispatch {
     already_checked: bool,
 }
 
-/// Execute one tool call on a blocking thread, fire `PostToolUse` hooks, and
-/// return the JSON result to append to conversation history.
-/// Returns `None` when the event channel is broken (caller should `break`).
-async fn execute_single_tool(
-    tool_call: &ToolCall,
+struct SingleToolExecution<'a> {
+    tool_call: &'a ToolCall,
     memory_db: Option<Arc<MemoryDb>>,
     app_config: Option<Arc<AppConfig>>,
     permission: ToolPermissionDispatch,
     policy_enforcer: Option<Arc<PolicyEnforcer>>,
     task_mgr: Arc<Mutex<crate::session::TaskManager>>,
-    session_id: Option<&str>,
-    hook_context: Option<(&crate::hooks::HookEngine, Value)>,
-    tx: &mpsc::Sender<AppEvent>,
-) -> Option<Value> {
+    session_id: Option<&'a str>,
+    hook_context: Option<(&'a crate::hooks::HookEngine, Value)>,
+    tx: &'a mpsc::Sender<AppEvent>,
+}
+
+/// Execute one tool call on a blocking thread, fire `PostToolUse` hooks, and
+/// return the JSON result to append to conversation history.
+/// Returns `None` when the event channel is broken (caller should `break`).
+async fn execute_single_tool(p: SingleToolExecution<'_>) -> Option<Value> {
+    let SingleToolExecution {
+        tool_call,
+        memory_db,
+        app_config,
+        permission,
+        policy_enforcer,
+        task_mgr,
+        session_id,
+        hook_context,
+        tx,
+    } = p;
     let tool_name = &tool_call.function.name;
     let tool_call_clone = tool_call.clone();
     let mem_db = memory_db;
@@ -2809,20 +2803,20 @@ async fn execute_tool_calls_for_tui(
             }
         );
 
-        let tool_result = execute_single_tool(
+        let tool_result = execute_single_tool(SingleToolExecution {
             tool_call,
-            memory_db.clone(),
-            app_config.clone(),
-            ToolPermissionDispatch {
+            memory_db: memory_db.clone(),
+            app_config: app_config.clone(),
+            permission: ToolPermissionDispatch {
                 mgr: permission_mgr.clone(),
                 already_checked: permission_already_checked,
             },
-            policy_enforcer.clone(),
-            task_mgr.clone(),
+            policy_enforcer: policy_enforcer.clone(),
+            task_mgr: task_mgr.clone(),
             session_id,
             hook_context,
             tx,
-        )
+        })
         .await;
         match tool_result {
             None => break, // channel broken

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -473,7 +473,7 @@ pub fn api_key_env_var_for_target(provider_name: &str) -> &'static str {
 /// Targets that should keep the selected provider even when a model ID looks
 /// like another vendor's namespace.
 ///
-/// Aggregators such as OpenRouter intentionally use slugs like
+/// Aggregators such as `OpenRouter` intentionally use slugs like
 /// `anthropic/claude-...`; local OpenAI-compatible servers often expose
 /// arbitrary names too. Prefix-based provider inference would otherwise route
 /// those requests to a different configured provider.

--- a/src/services/policy.rs
+++ b/src/services/policy.rs
@@ -90,7 +90,7 @@ pub struct EnterprisePolicy {
     /// The enforced value is:
     /// `cumulative_session_tokens + estimated_input_tokens + output_token_budget`.
     /// `output_token_budget` is the request's `max_tokens` when set, otherwise
-    /// OpenClaudia's default output budget. `None` disables this check.
+    /// `OpenClaudia`'s default output budget. `None` disables this check.
     #[serde(default)]
     pub max_session_tokens: Option<usize>,
     /// Per-tool invocation caps. Tools not present in the map are
@@ -128,7 +128,7 @@ pub struct ProviderRequestPolicyInput<'a> {
 }
 
 impl<'a> ProviderRequestPolicyInput<'a> {
-    /// Build input for request paths that use OpenClaudia's default output
+    /// Build input for request paths that use `OpenClaudia`'s default output
     /// token budget when no explicit `max_tokens` is present.
     #[must_use]
     pub fn new(

--- a/src/services/tool_executor.rs
+++ b/src/services/tool_executor.rs
@@ -1,6 +1,6 @@
 //! Shared local tool execution service.
 //!
-//! This centralizes the common "run an OpenClaudia tool locally" mechanics
+//! This centralizes the common "run an `OpenClaudia` tool locally" mechanics
 //! that were duplicated across TUI, legacy REPL, ACP local tools, subagents,
 //! and intercepted XML tools: optional enterprise tool cap, session id guard,
 //! active ledger installation, permission checked-vs-unchecked dispatch, and

--- a/src/subagent.rs
+++ b/src/subagent.rs
@@ -1537,7 +1537,7 @@ async fn run_subagent_inner(
                 };
             }
         };
-        if let Err(e) = check_provider_request_policy(&app_config, &typed_request) {
+        if let Err(e) = check_provider_request_policy(app_config, &typed_request) {
             let message = format!("Blocked by policy: {e}");
             BACKGROUND_AGENTS.fail(&agent_id, message.clone());
             store_transcript(&agent_id, messages, config.agent_type);
@@ -2028,10 +2028,10 @@ fn subagent_command_decision_matches(command: &str, argv: &[String]) -> bool {
         || argv.join(" ") == command
 }
 
-fn patch_mentions_tool_path(patch: &str, path: &str) -> bool {
-    let normalized = path.trim_start_matches("./");
+fn patch_mentions_tool_path(patch_text: &str, tool_path: &str) -> bool {
+    let normalized = tool_path.trim_start_matches("./");
     !normalized.is_empty()
-        && patch.lines().any(|line| {
+        && patch_text.lines().any(|line| {
             let line = line.trim_start_matches("./");
             line.contains(normalized)
         })
@@ -3010,7 +3010,7 @@ mod tests {
         );
     }
 
-    fn subagent_test_tool_call(name: &str, args: Value) -> ToolCall {
+    fn subagent_test_tool_call(name: &str, args: &Value) -> ToolCall {
         ToolCall {
             id: "call_1".to_string(),
             call_type: "function".to_string(),
@@ -3198,7 +3198,7 @@ mod tests {
     fn strip_subagent_decision_argument_removes_decision_before_dispatch() {
         let tool_call = subagent_test_tool_call(
             "bash",
-            json!({
+            &json!({
                 "command": "cargo test",
                 "decision": {
                     "kind": "run_command",

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -747,14 +747,17 @@ async fn resolve_provider_switch(
 }
 
 fn provider_switch_auth_to_vdd_auth(auth: &ProviderSwitchAuth) -> crate::vdd::VddProviderAuth {
-    if let Some(codex_auth) = &auth.codex_responses_auth {
-        crate::vdd::VddProviderAuth::codex_responses(codex_auth.clone())
-    } else if let Some(token) = &auth.claude_code_token {
-        crate::vdd::VddProviderAuth::claude_code_token(token.clone())
-    } else if let Some(api_key) = &auth.api_key {
-        crate::vdd::VddProviderAuth::api_key(api_key.clone())
-    } else {
-        crate::vdd::VddProviderAuth::None
+    match (
+        auth.codex_responses_auth.as_ref(),
+        auth.claude_code_token.as_ref(),
+        auth.api_key.as_ref(),
+    ) {
+        (Some(codex_auth), _, _) => {
+            crate::vdd::VddProviderAuth::codex_responses(codex_auth.clone())
+        }
+        (None, Some(token), _) => crate::vdd::VddProviderAuth::claude_code_token(token.clone()),
+        (None, None, Some(api_key)) => crate::vdd::VddProviderAuth::api_key(api_key.clone()),
+        (None, None, None) => crate::vdd::VddProviderAuth::None,
     }
 }
 
@@ -1429,7 +1432,7 @@ impl App {
     fn handle_app_event(&mut self, event: Result<AppEvent, std::sync::mpsc::RecvError>) -> bool {
         match event {
             Ok(AppEvent::Key(key)) => self.handle_key(key),
-            Ok(AppEvent::Paste(text)) => self.handle_paste(text),
+            Ok(AppEvent::Paste(text)) => self.handle_paste(&text),
             Ok(AppEvent::Tick) => {
                 self.spinner_frame = (self.spinner_frame + 1) % SPINNER_FRAMES.len();
             }
@@ -1815,7 +1818,7 @@ impl App {
         }
     }
 
-    fn handle_paste(&mut self, text: String) {
+    fn handle_paste(&mut self, text: &str) {
         if self.overlay.is_some()
             || self.is_waiting
             || self.pending_permission.is_some()
@@ -1824,7 +1827,7 @@ impl App {
             return;
         }
 
-        self.input.insert_str(&text);
+        self.input.insert_str(text);
     }
 
     /// Handle the universal Ctrl+C interrupt. Distinct from the per-mode
@@ -3526,6 +3529,24 @@ struct ApiTurnParams {
     tx: std::sync::mpsc::Sender<super::events::AppEvent>,
 }
 
+struct InitialTurnRequest<'a> {
+    session_id: &'a str,
+    session_messages: &'a [serde_json::Value],
+    policy_enforcer: &'a std::sync::Arc<crate::services::policy::PolicyEnforcer>,
+    model: &'a str,
+    wire_api: crate::pipeline::WireApi,
+    provider: &'a str,
+    effort_level: EffortLevel,
+    claude_code_token: Option<&'a str>,
+    prompt_blocks: Option<&'a crate::prompt::SystemPromptBlocks>,
+    tx: &'a std::sync::mpsc::Sender<super::events::AppEvent>,
+}
+
+struct PreparedInitialTurn {
+    task_obs: Option<crate::ledger::ObsId>,
+    request_body: serde_json::Value,
+}
+
 /// Shared context threaded through the agentic follow-up loop.
 struct AgenticCtx<'a> {
     client: &'a reqwest::Client,
@@ -4147,6 +4168,45 @@ async fn run_agentic_loop(ctx: &AgenticCtx<'_>, session_messages: &mut Vec<serde
     }
 }
 
+fn build_initial_turn_request(p: &InitialTurnRequest<'_>) -> Option<PreparedInitialTurn> {
+    let task_obs = observe_turn_user_task(p.session_id, p.session_messages);
+    let request_messages =
+        match request_messages_with_grounding(p.session_id, task_obs, p.session_messages) {
+            Ok(messages) => messages,
+            Err(e) => {
+                send_or_warn(p.tx, super::events::AppEvent::ApiError(e), p.session_id);
+                return None;
+            }
+        };
+    if !check_provider_request_policy_for_messages(
+        p.policy_enforcer,
+        p.model,
+        &request_messages,
+        p.tx,
+        p.session_id,
+    ) {
+        return None;
+    }
+    match crate::pipeline::build_request_for_wire(
+        p.wire_api,
+        p.provider,
+        p.model,
+        &request_messages,
+        p.effort_level.as_str(),
+        p.claude_code_token,
+        p.prompt_blocks,
+    ) {
+        Ok(request_body) => Some(PreparedInitialTurn {
+            task_obs,
+            request_body,
+        }),
+        Err(e) => {
+            send_or_warn(p.tx, super::events::AppEvent::ApiError(e), p.session_id);
+            None
+        }
+    }
+}
+
 /// Run a complete API turn: pre-turn hooks, first `run_turn`, and an agentic
 /// follow-up loop when tool calls are present.
 async fn run_api_turn_async(p: ApiTurnParams) {
@@ -4178,44 +4238,26 @@ async fn run_api_turn_async(p: ApiTurnParams) {
             return;
         }
     }
-    let task_obs = observe_turn_user_task(&session_id, &session_messages);
-    let request_messages =
-        match request_messages_with_grounding(&session_id, task_obs, &session_messages) {
-            Ok(messages) => messages,
-            Err(e) => {
-                send_or_warn(&tx, super::events::AppEvent::ApiError(e), &session_id);
-                return;
-            }
-        };
-    if !check_provider_request_policy_for_messages(
-        &policy_enforcer,
-        &model,
-        &request_messages,
-        &tx,
-        &session_id,
-    ) {
-        return;
-    }
-    let request_body = match crate::pipeline::build_request_for_wire(
+    let initial_request = InitialTurnRequest {
+        session_id: &session_id,
+        session_messages: &session_messages,
+        policy_enforcer: &policy_enforcer,
+        model: &model,
         wire_api,
-        &provider,
-        &model,
-        &request_messages,
-        effort_level.as_str(),
-        claude_code_token.as_deref(),
-        prompt_blocks.as_ref(),
-    ) {
-        Ok(request_body) => request_body,
-        Err(e) => {
-            send_or_warn(&tx, super::events::AppEvent::ApiError(e), &session_id);
-            return;
-        }
+        provider: &provider,
+        effort_level,
+        claude_code_token: claude_code_token.as_deref(),
+        prompt_blocks: prompt_blocks.as_ref(),
+        tx: &tx,
+    };
+    let Some(initial_turn) = build_initial_turn_request(&initial_request) else {
+        return;
     };
     match crate::pipeline::run_turn(crate::pipeline::RunTurnParams {
         client: &client,
         endpoint: &endpoint,
         headers: &headers,
-        request_body: &request_body,
+        request_body: &initial_turn.request_body,
         provider: &provider,
         memory_db: memory_db.clone(),
         app_config: app_config.clone(),
@@ -4253,7 +4295,7 @@ async fn run_api_turn_async(p: ApiTurnParams) {
                     policy_enforcer,
                     task_mgr,
                     session_id: &session_id,
-                    task_obs,
+                    task_obs: initial_turn.task_obs,
                     tx: &tx,
                 },
             )

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -139,7 +139,7 @@ impl TextInput {
     }
 }
 
-fn wrapped_rows(char_count: usize, width: usize) -> usize {
+const fn wrapped_rows(char_count: usize, width: usize) -> usize {
     if char_count == 0 {
         1
     } else {

--- a/src/tui/messages.rs
+++ b/src/tui/messages.rs
@@ -1,12 +1,10 @@
 //! Scrollable message list for the TUI.
 
+use std::collections::VecDeque;
 use std::str::FromStr;
 use std::time::Instant;
 
-use ratatui::{
-    prelude::*,
-    widgets::{Paragraph, Wrap},
-};
+use ratatui::{buffer::CellWidth, prelude::*, widgets::Paragraph};
 
 use super::{GOLD, PURPLE, USER_BLUE};
 
@@ -221,8 +219,7 @@ impl EffortLevel {
     pub const fn symbol(self) -> &'static str {
         match self {
             Self::None => "\u{25CC}",
-            Self::Minimal => "\u{25CB}",
-            Self::Low => "\u{25CB}",
+            Self::Minimal | Self::Low => "\u{25CB}",
             Self::Medium => "\u{25D0}",
             Self::High => "\u{25CF}",
             Self::Max => "\u{25C6}",
@@ -236,10 +233,9 @@ impl EffortLevel {
     pub const fn cycled(self) -> Self {
         match self {
             Self::None => Self::Minimal,
-            Self::Minimal => Self::Low,
+            Self::Minimal | Self::High | Self::Max | Self::Auto => Self::Low,
             Self::Low => Self::Medium,
             Self::Medium => Self::High,
-            Self::High | Self::Max | Self::Auto => Self::Low,
         }
     }
 
@@ -283,7 +279,6 @@ impl EffortLevel {
 
         match provider.to_ascii_lowercase().as_str() {
             "openai" => OPENAI,
-            "anthropic" | "google" | "gemini" => ANTHROPIC_GEMINI,
             "deepseek" => DEEPSEEK,
             "zai" | "glm" | "zhipu" if model.eq_ignore_ascii_case("glm-5.2") => GLM_REASONING,
             "qwen" | "alibaba" | "zai" | "glm" | "zhipu" | "kimi" | "moonshot" | "minimax" => {
@@ -403,6 +398,13 @@ pub struct MessageList {
     /// Accumulator for the full thinking stream. Rendered while live so the
     /// user can see progress during long reasoning/tool-planning phases.
     pub thinking_buffer: String,
+}
+
+struct VisualGrapheme {
+    symbol: String,
+    style: Style,
+    width: u16,
+    is_whitespace: bool,
 }
 
 impl MessageList {
@@ -696,33 +698,167 @@ impl MessageList {
         lines
     }
 
+    fn saturating_u16(value: usize) -> u16 {
+        u16::try_from(value).unwrap_or(u16::MAX)
+    }
+
+    fn visual_line_from_graphemes(
+        graphemes: Vec<VisualGrapheme>,
+        alignment: Option<Alignment>,
+    ) -> Line<'static> {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        for grapheme in graphemes {
+            if let Some(last) = spans.last_mut() {
+                if last.style == grapheme.style {
+                    last.content.to_mut().push_str(&grapheme.symbol);
+                    continue;
+                }
+            }
+            spans.push(Span::styled(grapheme.symbol, grapheme.style));
+        }
+
+        let mut line = Line::from(spans);
+        line.alignment = alignment;
+        line
+    }
+
+    const fn empty_visual_line(source: &Line<'_>) -> Line<'static> {
+        Line {
+            style: source.style,
+            alignment: source.alignment,
+            spans: Vec::new(),
+        }
+    }
+
+    fn wrap_line(source: &Line<'_>, width: u16) -> Vec<Line<'static>> {
+        let mut wrapped = Vec::new();
+        let mut pending_line = Vec::new();
+        let mut pending_word = Vec::new();
+        let mut pending_whitespace = VecDeque::new();
+        let mut line_width = 0;
+        let mut word_width = 0;
+        let mut whitespace_width = 0;
+        let mut non_whitespace_previous = false;
+
+        for styled in source.styled_graphemes(Style::default()) {
+            let grapheme = VisualGrapheme {
+                symbol: styled.symbol.to_string(),
+                style: styled.style,
+                width: styled.symbol.cell_width(),
+                is_whitespace: styled.is_whitespace(),
+            };
+
+            if grapheme.width > width {
+                continue;
+            }
+
+            let is_whitespace = grapheme.is_whitespace;
+            let word_found = non_whitespace_previous && grapheme.is_whitespace;
+            let untrimmed_overflow =
+                pending_line.is_empty() && word_width + whitespace_width + grapheme.width > width;
+
+            if word_found || untrimmed_overflow {
+                pending_line.extend(std::mem::take(&mut pending_whitespace));
+                line_width += whitespace_width;
+                pending_line.append(&mut pending_word);
+                line_width += word_width;
+                whitespace_width = 0;
+                word_width = 0;
+            }
+
+            let line_full = line_width >= width;
+            let pending_word_overflow =
+                grapheme.width > 0 && line_width + whitespace_width + word_width >= width;
+
+            if line_full || pending_word_overflow {
+                let mut remaining_width = width.saturating_sub(line_width);
+                wrapped.push(Self::visual_line_from_graphemes(
+                    std::mem::take(&mut pending_line),
+                    source.alignment,
+                ));
+                line_width = 0;
+
+                while let Some(grapheme) = pending_whitespace.front() {
+                    if grapheme.width > remaining_width {
+                        break;
+                    }
+
+                    whitespace_width -= grapheme.width;
+                    remaining_width -= grapheme.width;
+                    pending_whitespace.pop_front();
+                }
+
+                if grapheme.is_whitespace && pending_whitespace.is_empty() {
+                    continue;
+                }
+            }
+
+            if grapheme.is_whitespace {
+                whitespace_width += grapheme.width;
+                pending_whitespace.push_back(grapheme);
+            } else {
+                word_width += grapheme.width;
+                pending_word.push(grapheme);
+            }
+
+            non_whitespace_previous = !is_whitespace;
+        }
+
+        pending_line.extend(pending_whitespace);
+        pending_line.append(&mut pending_word);
+
+        if !pending_line.is_empty() {
+            wrapped.push(Self::visual_line_from_graphemes(
+                pending_line,
+                source.alignment,
+            ));
+        }
+        if wrapped.is_empty() {
+            wrapped.push(Self::empty_visual_line(source));
+        }
+
+        wrapped
+    }
+
+    fn wrap_lines(lines: &[Line<'_>], width: u16) -> Vec<Line<'static>> {
+        if width == 0 {
+            return Vec::new();
+        }
+
+        lines
+            .iter()
+            .flat_map(|line| Self::wrap_line(line, width))
+            .collect()
+    }
+
     /// Render the message list into a frame area.
     /// Content is anchored to the bottom — empty space is at the top, not below.
     pub fn render(&self, frame: &mut Frame, area: Rect) {
-        let mut lines = self.build_lines();
-        #[allow(clippy::cast_possible_truncation)] // line count bounded by terminal height
-        let total = lines.len() as u16;
-        let visible = area.height;
+        if area.is_empty() {
+            return;
+        }
+
+        let logical_lines = self.build_lines();
+        let mut lines = Self::wrap_lines(&logical_lines, area.width);
+        let mut total = lines.len();
+        let visible = usize::from(area.height);
 
         // Pad the top with empty lines so content anchors to the bottom
         if total < visible {
-            let pad = (visible - total) as usize;
+            let pad = visible - total;
             let mut padded = vec![Line::from(""); pad];
             padded.append(&mut lines);
             lines = padded;
+            total = visible;
         }
 
-        #[allow(clippy::cast_possible_truncation)]
-        let total = lines.len() as u16;
         let scroll = if total > visible {
-            (total - visible).saturating_sub(self.scroll_offset)
+            (total - visible).saturating_sub(usize::from(self.scroll_offset))
         } else {
             0
         };
 
-        let paragraph = Paragraph::new(lines)
-            .wrap(Wrap { trim: false })
-            .scroll((scroll, 0));
+        let paragraph = Paragraph::new(lines).scroll((Self::saturating_u16(scroll), 0));
 
         frame.render_widget(paragraph, area);
     }
@@ -737,6 +873,24 @@ impl Default for MessageList {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn rendered_rows(backend: &TestBackend) -> Vec<String> {
+        let area = *backend.buffer().area();
+        let mut rows = Vec::with_capacity(usize::from(area.height));
+        for y in 0..area.height {
+            let mut row = String::new();
+            for x in 0..area.width {
+                let cell = backend
+                    .buffer()
+                    .cell((x, y))
+                    .expect("test coordinates are inside the buffer");
+                row.push_str(cell.symbol());
+            }
+            rows.push(row);
+        }
+        rows
+    }
 
     // ── MessageKind tests ────────────────────────────────────────────────────
 
@@ -1040,6 +1194,30 @@ mod tests {
         assert_eq!(ml.scroll_offset, 2);
         ml.scroll_to_bottom();
         assert_eq!(ml.scroll_offset, 0);
+    }
+
+    #[test]
+    fn render_bottom_anchor_counts_wrapped_visual_rows() {
+        let mut ml = MessageList::new();
+        ml.add(DisplayMessage::assistant(
+            "alpha bravo charlie delta echo foxtrot golf hotel india juliet",
+        ));
+
+        let backend = TestBackend::new(16, 4);
+        let mut terminal = Terminal::new(backend).expect("test backend should initialize");
+        terminal
+            .draw(|frame| ml.render(frame, frame.area()))
+            .expect("message list should render");
+
+        let rows = rendered_rows(terminal.backend());
+        assert!(
+            rows.iter().any(|row| row.contains("juliet")),
+            "bottom-anchored viewport should include the final wrapped row; rows={rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|row| row.contains("Claudia")),
+            "wrapped content taller than the viewport should scroll past the header; rows={rows:?}"
+        );
     }
 
     // ── crosslink #482: scroll_offset semantics contract ────────────────────

--- a/src/vdd/transport.rs
+++ b/src/vdd/transport.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use tracing::{debug, info, warn};
 
 use crate::config::{AppConfig, ProviderConfig, VddConfig};
-use crate::providers::{get_adapter, ApiKey};
+use crate::providers::{get_adapter, ApiKey, ProviderAdapter};
 use crate::proxy::ChatCompletionRequest;
 use crate::session::TokenUsage;
 
@@ -41,17 +41,17 @@ impl std::fmt::Debug for VddProviderAuth {
 
 impl VddProviderAuth {
     #[must_use]
-    pub fn api_key(api_key: ApiKey) -> Self {
+    pub const fn api_key(api_key: ApiKey) -> Self {
         Self::ApiKey(api_key)
     }
 
     #[must_use]
-    pub fn claude_code_token(token: String) -> Self {
+    pub const fn claude_code_token(token: String) -> Self {
         Self::ClaudeCodeToken(token)
     }
 
     #[must_use]
-    pub fn codex_responses(auth: crate::codex_credentials::CodexResponsesAuth) -> Self {
+    pub const fn codex_responses(auth: crate::codex_credentials::CodexResponsesAuth) -> Self {
         Self::CodexResponses(auth)
     }
 }
@@ -275,6 +275,54 @@ async fn send_to_codex_responses(
     ))
 }
 
+fn adversary_headers_and_endpoint(
+    config: &VddConfig,
+    provider_config: &ProviderConfig,
+    adapter: &dyn ProviderAdapter,
+    request: &ChatCompletionRequest,
+    transformed: &mut Value,
+    runtime_auth: Option<&VddProviderAuth>,
+) -> Result<(Vec<(String, String)>, String), VddError> {
+    match runtime_auth {
+        Some(VddProviderAuth::ApiKey(api_key)) => Ok((
+            adapter.get_headers(api_key),
+            adapter.chat_endpoint(&request.model),
+        )),
+        Some(VddProviderAuth::ClaudeCodeToken(token)) => {
+            if !config.adversary.provider.eq_ignore_ascii_case("anthropic") {
+                return Err(VddError::ConfigError(format!(
+                    "Claude Code auth can only be used with Anthropic VDD adversary, got '{}'",
+                    config.adversary.provider
+                )));
+            }
+            crate::claude_credentials::inject_system_prompt(transformed);
+            Ok((
+                crate::claude_credentials::get_oauth_headers(token),
+                crate::claude_credentials::get_oauth_endpoint(&request.model),
+            ))
+        }
+        Some(VddProviderAuth::None) => Ok((Vec::new(), adapter.chat_endpoint(&request.model))),
+        None => {
+            let api_key = config
+                .adversary
+                .api_key
+                .as_ref()
+                .or(provider_config.api_key.as_ref())
+                .ok_or_else(|| {
+                    VddError::ConfigError(format!(
+                        "No API key for adversary provider '{}'",
+                        config.adversary.provider
+                    ))
+                })?;
+            Ok((
+                adapter.get_headers(api_key),
+                adapter.chat_endpoint(&request.model),
+            ))
+        }
+        Some(VddProviderAuth::CodexResponses(_)) => unreachable!("handled above"),
+    }
+}
+
 /// Send a request to the adversary provider. Returns (`response_text`, `token_usage`).
 ///
 /// Per-request timeout — crosslink #496 — wraps both the HTTP send and the
@@ -319,44 +367,14 @@ pub async fn send_to_adversary(
         .transform_request(request)
         .map_err(|e| VddError::AdversaryRequestFailed(e.to_string()))?;
 
-    let (headers, endpoint) = match runtime_auth {
-        Some(VddProviderAuth::ApiKey(api_key)) => (
-            adapter.get_headers(api_key),
-            adapter.chat_endpoint(&request.model),
-        ),
-        Some(VddProviderAuth::ClaudeCodeToken(token)) => {
-            if !config.adversary.provider.eq_ignore_ascii_case("anthropic") {
-                return Err(VddError::ConfigError(format!(
-                    "Claude Code auth can only be used with Anthropic VDD adversary, got '{}'",
-                    config.adversary.provider
-                )));
-            }
-            crate::claude_credentials::inject_system_prompt(&mut transformed);
-            (
-                crate::claude_credentials::get_oauth_headers(token),
-                crate::claude_credentials::get_oauth_endpoint(&request.model),
-            )
-        }
-        Some(VddProviderAuth::None) => (Vec::new(), adapter.chat_endpoint(&request.model)),
-        None => {
-            let api_key = config
-                .adversary
-                .api_key
-                .as_ref()
-                .or(provider_config.api_key.as_ref())
-                .ok_or_else(|| {
-                    VddError::ConfigError(format!(
-                        "No API key for adversary provider '{}'",
-                        config.adversary.provider
-                    ))
-                })?;
-            (
-                adapter.get_headers(api_key),
-                adapter.chat_endpoint(&request.model),
-            )
-        }
-        Some(VddProviderAuth::CodexResponses(_)) => unreachable!("handled above"),
-    };
+    let (headers, endpoint) = adversary_headers_and_endpoint(
+        config,
+        provider_config,
+        adapter,
+        request,
+        &mut transformed,
+        runtime_auth,
+    )?;
 
     let provider_name = adapter.name().to_string();
 

--- a/tests/cli_exit_status_e2e.rs
+++ b/tests/cli_exit_status_e2e.rs
@@ -123,9 +123,12 @@ fn default_tui_auth_failure_does_not_create_project_state_without_config() {
             .collect::<Vec<_>>();
         assert!(
             !log_entries.is_empty()
-                && log_entries
-                    .iter()
-                    .all(|name| name.starts_with("tui-") && name.ends_with(".log")),
+                && log_entries.iter().all(|name| {
+                    name.starts_with("tui-")
+                        && std::path::Path::new(name)
+                            .extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("log"))
+                }),
             "default startup without config must only create TUI log files; got {log_entries:?}"
         );
     }

--- a/tests/get_adapter_alias_matrix_e2e.rs
+++ b/tests/get_adapter_alias_matrix_e2e.rs
@@ -263,6 +263,10 @@ fn unknown_provider_error_carries_documented_supported_list() {
         "lmstudio",
         "localai",
         "text-generation-webui",
+        "openrouter",
+        "opencode",
+        "opencode-go",
+        "openai-compatible",
     ] {
         assert!(
             supported.iter().any(|s| s == name),
@@ -272,8 +276,8 @@ fn unknown_provider_error_carries_documented_supported_list() {
 }
 
 #[test]
-fn unknown_provider_supported_list_has_exactly_18_entries() {
-    // PINS COUNT: 18 documented names (9 canonical + 9 aliases).
+fn unknown_provider_supported_list_has_exactly_22_entries() {
+    // PINS COUNT: documented names accepted by runtime provider dispatch.
     let outcome = get_adapter("xyz");
     let Err(err) = outcome else {
         panic!("expected Err")
@@ -283,8 +287,8 @@ fn unknown_provider_supported_list_has_exactly_18_entries() {
     };
     assert_eq!(
         supported.len(),
-        18,
-        "MUST list exactly 18 supported names; got {supported:?}"
+        22,
+        "MUST list exactly 22 supported names; got {supported:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Fix repo-wide clippy failures without adding new lint suppressions.
- Refactor oversized/auth/tool execution paths into focused helpers and parameter structs.
- Fix the TUI wrapped-message bottom-anchor behavior and add a regression test.
- Refresh stale docs/tests for provider support and README URL validation.

## Validation

- `cargo fmt --check`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo test --lib --tests`
- TUI smoke run in tmux with screenshot artifact at `/tmp/openclaudia-lintfix/app-screenshot.svg`