### PR TITLE
Harden agent sandbox boundaries and refresh dependencies

### DIFF
--- a/.github/workflows/sandbox-security.yml
+++ b/.github/workflows/sandbox-security.yml
@@ -16,8 +16,24 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - name: Install Bubblewrap
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - name: Install and authorize Bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apparmor-profiles bubblewrap
+          sudo install -m 0644 \
+            /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+            /etc/apparmor.d/bwrap-userns-restrict
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+          /usr/bin/bwrap \
+            --unshare-all \
+            --unshare-user \
+            --disable-userns \
+            --assert-userns-disabled \
+            --cap-drop ALL \
+            --ro-bind / / \
+            --proc /proc \
+            --dev /dev \
+            -- /usr/bin/true
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --all-targets -- --test-threads=1

--- a/.github/workflows/sandbox-security.yml
+++ b/.github/workflows/sandbox-security.yml
@@ -1,0 +1,37 @@
+name: Sandbox security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Install Bubblewrap
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test --all-targets -- --test-threads=1
+      - run: cargo test --test sandbox_escape_e2e -- --test-threads=1
+      - run: cargo test --test session_filesystem_capabilities_e2e -- --test-threads=1
+
+  platform-fail-closed:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check --all-targets
+      - run: cargo test --test sandbox_platform_fail_closed_e2e -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -181,13 +181,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -237,14 +237,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -254,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -273,7 +274,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -331,10 +332,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
+name = "base64"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bincode"
@@ -383,9 +384,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -408,12 +409,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -430,9 +431,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -448,9 +449,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -472,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -496,15 +497,15 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -547,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -557,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -569,14 +570,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -641,35 +642,29 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.24"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "async-trait",
  "pathdiff",
  "serde_core",
  "serde_json",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -768,18 +763,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crosslink"
@@ -790,7 +785,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "crossterm",
@@ -824,11 +819,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.2.1",
+ "mio 1.2.2",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -901,7 +896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -924,14 +919,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -946,7 +941,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -980,7 +975,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -993,7 +988,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1004,7 +999,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1015,7 +1010,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1055,16 +1050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,7 +1073,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1098,7 +1083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1120,7 +1105,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1147,7 +1132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
@@ -1189,19 +1174,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1242,24 +1227,22 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -1272,9 +1255,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1369,9 +1352,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -1390,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -1491,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1506,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1516,15 +1499,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1533,38 +1516,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1626,11 +1609,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1724,13 +1705,13 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.6",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -1750,16 +1731,16 @@ checksum = "5754ca220578ad74a5d5174c8ca2ff956fd3b94025f870844de1e910b47dfee5"
 dependencies = [
  "anyhow",
  "auto_generate_cdp",
- "base64",
+ "base64 0.22.1",
  "derive_builder",
  "directories",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tungstenite",
  "ureq",
  "url",
@@ -1816,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "htmd"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+checksum = "a5a1c7113c831fec68cbd79cd8bf281a84e5b6943f51473dc266b0b88a6a017e"
 dependencies = [
  "html5ever 0.38.0",
  "markup5ever_rcdom",
@@ -1847,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1857,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1867,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1898,18 +1879,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1949,7 +1930,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2127,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2160,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2195,7 +2176,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2237,7 +2218,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2252,7 +2233,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2271,24 +2252,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2303,7 +2284,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2322,7 +2303,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2346,9 +2327,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2358,9 +2339,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2382,7 +2363,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2420,15 +2401,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2441,9 +2422,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -2509,9 +2490,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -2574,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2615,7 +2596,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2627,9 +2608,9 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
 ]
@@ -2640,9 +2621,9 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -2668,7 +2649,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2704,7 +2685,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2750,7 +2731,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -2762,7 +2743,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2773,7 +2754,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2792,7 +2773,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2803,7 +2784,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2826,7 +2807,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2857,7 +2838,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "clap",
  "config",
@@ -2873,7 +2854,7 @@ dependencies = [
  "libc",
  "predicates",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ratatui",
  "regex",
  "reqwest 0.13.4",
@@ -2888,7 +2869,7 @@ dependencies = [
  "similar",
  "syntect",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-test",
  "tower",
@@ -2945,7 +2926,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2995,9 +2976,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3005,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3015,25 +2996,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3084,7 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3107,7 +3087,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3120,7 +3100,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3148,16 +3128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,11 +3135,11 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap",
  "quick-xml",
  "serde",
@@ -3182,7 +3152,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3203,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-pty"
@@ -3286,9 +3256,9 @@ checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3301,9 +3271,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3314,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3332,28 +3302,28 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3361,21 +3331,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3383,23 +3354,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3428,18 +3399,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3447,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3491,6 +3462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3521,7 +3501,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
@@ -3531,7 +3511,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -3586,7 +3566,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -3606,7 +3586,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3617,14 +3597,14 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3634,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3655,7 +3635,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -3693,7 +3673,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3752,7 +3732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3761,7 +3741,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3772,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3783,32 +3763,33 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3825,7 +3806,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3834,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3862,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3911,9 +3892,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3929,11 +3910,11 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "clipboard-win",
  "home",
@@ -3957,7 +3938,7 @@ checksum = "64e5587417a3c4e16a4415e8d7d07f80998ed835ade621d19dfbe9fbe3205b0f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4011,7 +3992,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4034,7 +4015,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -4055,9 +4036,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4065,29 +4046,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4163,9 +4144,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4253,7 +4234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.1",
+ "mio 1.2.2",
  "signal-hook",
 ]
 
@@ -4269,24 +4250,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4327,9 +4305,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4344,16 +4322,6 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -4429,7 +4397,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4451,9 +4419,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4477,7 +4456,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4496,7 +4475,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "yaml-rust",
 ]
@@ -4507,7 +4486,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4537,12 +4516,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -4551,7 +4529,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -4586,8 +4564,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
- "bitflags 2.13.0",
+ "base64 0.22.1",
+ "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -4632,11 +4610,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4647,25 +4625,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -4686,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "js-sys",
@@ -4709,9 +4687,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4729,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4744,13 +4722,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.1",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4761,13 +4739,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4782,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4816,14 +4794,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4891,7 +4870,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4918,7 +4897,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "http",
  "http-body",
@@ -4961,7 +4940,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5033,9 +5012,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5062,7 +5041,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "web-time",
 ]
@@ -5142,7 +5121,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -5160,7 +5139,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -5185,12 +5164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,9 +5183,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -5293,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5306,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5316,9 +5289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5326,22 +5299,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -5361,9 +5334,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5393,18 +5366,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5489,9 +5462,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -5548,7 +5521,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5559,7 +5532,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5830,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5863,7 +5836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -5957,28 +5930,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5998,7 +5971,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6038,7 +6011,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6047,7 +6020,7 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
@@ -6070,15 +6043,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,11 +81,11 @@ regex = "1"
 shlex = "2"
 
 # OAuth and cryptography
-base64 = "0.22"
+base64 = "0.23"
 sha2 = "0.11"
 rand = "0.10"
 url = "2"
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 urlencoding = "2"
 
 # CLI enhancements

--- a/README.md
+++ b/README.md
@@ -43,9 +43,17 @@ OpenClaudia is a Rust-based CLI that transforms any LLM into an agentic coding a
 ### Required
 
 - **Rust** — Install via [rustup](https://rustup.rs/)
-- **Git Bash** (Windows only) — Comes with [Git for Windows](https://git-scm.com/download/win)
-  - OpenClaudia uses Git Bash on Windows for Unix command compatibility
+- **bubblewrap** (Linux) — Required for OS containment of agent Bash and
+  project-controlled quality-gate processes (`apt install bubblewrap`,
+  `dnf install bubblewrap`, or your distribution equivalent)
+- **Git Bash** (Windows compatibility mode only) — Comes with [Git for Windows](https://git-scm.com/download/win)
+  - OpenClaudia can use Git Bash when the host explicitly opts out of sandboxing
   - Ensure Git is in your PATH
+
+Agent subprocesses fail closed when a supported OS sandbox is unavailable.
+For emergency compatibility only, a host user can explicitly opt out before
+startup with `OPENCLAUDIA_BASH_SANDBOX=off`; models cannot set this through
+tool arguments, and OpenClaudia logs a warning when the opt-out is active.
 
 ## Installation
 
@@ -106,6 +114,20 @@ openclaudia --mode debug      # Investigation-first debugging
 | `OPENROUTER_API_KEY` | OpenRouter | For OpenRouter |
 | `OPENCODE_API_KEY` | OpenCode Go | For OpenCode Go |
 | `OPENAI_COMPATIBLE_API_KEY` or `API_KEY` | Generic OpenAI-compatible endpoint | For `openai-compatible` |
+
+Sandbox policy is fixed at host startup:
+
+| Variable | Effect |
+|---|---|
+| `OPENCLAUDIA_PROJECT_SECRET_MASKS` | Comma-separated project-relative paths hidden from agent file tools and subprocesses |
+| `OPENCLAUDIA_AGENT_READ_ONLY_ROOTS` | Platform path-list of additional immutable session roots |
+| `OPENCLAUDIA_AGENT_READ_WRITE_ROOTS` | Platform path-list of additional writable session roots |
+| `OPENCLAUDIA_AGENT_ENV_GRANTS` | Comma-separated exact environment names granted to sandboxed agent processes |
+| `OPENCLAUDIA_AGENT_NETWORK` | Must be `denied` (default); unsupported grants fail closed |
+| `OPENCLAUDIA_TRUST_MCP_SERVERS` | Comma-separated exact `plugin/server` names approved from repository MCP config |
+| `OPENCLAUDIA_MCP_ENV_GRANTS` | Comma-separated exact sensitive environment names an approved MCP server may receive |
+| `OPENCLAUDIA_TRUST_UNSANDBOXED_HOOKS` | Set to `true` only to authorize hook `none`/`env_scrub` modes |
+| `OPENCLAUDIA_BASH_SANDBOX` | `on` by default; `off` is an explicit host-wide emergency opt-out |
 
 ### Config File
 
@@ -204,6 +226,24 @@ keybindings:
   tab: toggle_mode
   escape: cancel
 ```
+
+## Sandbox Security
+
+Linux agent subprocesses run inside named Bubblewrap profiles with filesystem
+capabilities, network denial, seccomp, resource/output limits, inherited-FD
+closure, and complete process-tree cancellation. File operations use
+descriptor-relative resolution, and ACP routes filesystem/search operations
+through those same local primitives.
+
+The project root is readable and writable by agent code by default, so secrets
+stored in `.env`, fixtures, or generated files are in scope unless masked.
+`.openclaudia` and `.claude` stay hidden. macOS and Windows agent subprocesses
+currently fail closed; they never silently fall back to host execution.
+
+Run `openclaudia doctor` to inspect the effective redacted policy. See the
+[agent sandbox threat model](docs/sandbox-threat-model.md) and
+[subprocess inventory](docs/subprocess-inventory.md) for platform support,
+trust boundaries, limitations, and incident response.
 
 ## CLI Commands
 

--- a/docs/sandbox-threat-model.md
+++ b/docs/sandbox-threat-model.md
@@ -69,8 +69,13 @@ surface starts. Each process starts from an empty mount namespace with:
 - explicit session roots mounted with their declared access;
 - private `/tmp`, `/run`, `/proc`, `/dev`, `HOME`, and package-manager state;
 - no host `/sys`, `/etc`, home directory, runtime directory, or IPC sockets;
-- all capabilities dropped, a new PID/user/network namespace, nested user
-  namespaces disabled, and parent-death/process-group cleanup;
+- all capabilities dropped, new PID/user namespaces, nested user namespaces
+  disabled, and parent-death/process-group cleanup;
+- a new network namespace when the host permits Bubblewrap to configure its
+  loopback device; on restricted container hosts that reject only that
+  operation, the probed fallback retains the host network namespace while the
+  seccomp filter still denies socket creation and use and inherited descriptors
+  remain closed;
 - a versioned seccomp filter denying socket creation, mount and namespace
   changes, `ptrace`, BPF, performance events, keyrings, kernel module/kexec,
   cross-process memory access, file-handle APIs, `userfaultfd`, and

--- a/docs/sandbox-threat-model.md
+++ b/docs/sandbox-threat-model.md
@@ -1,0 +1,183 @@
+# Agent sandbox threat model
+
+## Security objective
+
+Repository content, model output, hook configuration, language-server
+configuration, analyzers, quality gates, and untrusted MCP configuration are
+hostile inputs. An agent-operated path must not read or modify data outside
+its immutable session capabilities, reach host networking or IPC, inherit host
+credentials, or leave processes behind.
+
+Permission prompts remain useful defense in depth, but they are not the
+isolation boundary. The boundary is formed by per-session filesystem
+capabilities plus the named subprocess sandbox profiles.
+
+## Trust classes
+
+- **Agent-operated:** Bash, background Bash, file/list/glob/grep/notebook
+  tools, ACP-local tools, repository hooks, LSPs, analyzers, document parsers,
+  quality gates, and Git worktree tools. These use capability-safe filesystem
+  primitives or a named sandbox profile.
+- **Brokered:** provider HTTP, web/search, and remote MCP HTTP. These execute
+  outside the subprocess sandbox and enforce URL/SSRF, credential, timeout,
+  and response-size policies at their own boundary.
+- **Trusted host:** interactive TUI `!` commands, browser opening, plugin
+  administration, CLI Git/GitHub operations, and transcript metadata. They
+  are reachable only from user-operated surfaces, not the model tool
+  registry. Repository MCP servers require an exact host-startup trust grant
+  even though their stdio process is still sandboxed.
+
+## Session capabilities
+
+A session pins its canonical project root, working directory, read-only and
+read-write roots, private temporary directory, owner ID, exact environment
+grants, denied project paths, and network policy. The context is immutable
+after first registration. Background process lookup, signaling, cancellation,
+and cleanup are owner-bound.
+
+On Unix, root directories are opened when the context is created. Linux file
+operations use `openat2` with `RESOLVE_BENEATH`, `RESOLVE_NO_MAGICLINKS`, and
+`RESOLVE_NO_SYMLINKS`. macOS uses an `openat`/`O_NOFOLLOW`
+descriptor-relative component walk. Symlinks are intentionally unsupported,
+including symlinks whose targets remain inside a granted root. This policy is
+stricter and easier to enforce atomically. Windows file tools fail closed
+until a reparse-point-safe handle backend exists.
+
+Linux subprocess capability roots and validated Git metadata are also passed
+to Bubblewrap as pinned descriptors (`--bind-fd`/`--ro-bind-fd`), not reopened
+by pathname after validation. Only those descriptors and the seccomp-filter
+descriptor survive the launcher's inherited-file-descriptor closure.
+
+The project is read-write by default. This includes `.env`, local test keys,
+fixtures, and generated credentials stored in the repository. `.openclaudia`
+and `.claude` are always masked. Operators can add comma-separated
+project-relative masks with `OPENCLAUDIA_PROJECT_SECRET_MASKS`. Hardlinked
+read targets are rejected on Unix, and writable project trees are rejected if
+a multiply-linked inode has aliases outside the tree.
+
+Session temporary directories are private (`0700` on Unix), individually
+granted, and removed at session release only after an identity check. The
+process-wide OS temporary directory is never a file-tool capability.
+
+## Linux subprocess boundary
+
+Linux uses a root-owned, non-writable Bubblewrap binary found only in trusted
+system locations. Startup probes namespace creation before an agent-capable
+surface starts. Each process starts from an empty mount namespace with:
+
+- selected system and toolchain runtime trees mounted read-only;
+- explicit session roots mounted with their declared access;
+- private `/tmp`, `/run`, `/proc`, `/dev`, `HOME`, and package-manager state;
+- no host `/sys`, `/etc`, home directory, runtime directory, or IPC sockets;
+- all capabilities dropped, a new PID/user/network namespace, nested user
+  namespaces disabled, and parent-death/process-group cleanup;
+- a versioned seccomp filter denying socket creation, mount and namespace
+  changes, `ptrace`, BPF, performance events, keyrings, kernel module/kexec,
+  cross-process memory access, file-handle APIs, `userfaultfd`, and
+  `io_uring`;
+- inherited descriptors closed except stdio and the pinned seccomp filter;
+- CPU, address-space, process/thread, file-descriptor, per-file-size,
+  output-capture, and wall-time limits.
+
+Writable roots are scanned before launch. Nested mounts, external hardlink
+aliases, Unix sockets, FIFOs, and device nodes make startup fail closed.
+Bubblewrap uses non-recursive binds in a private mount namespace so a later
+host mount does not become a sandbox mount.
+
+All subprocess callers select one of: `Shell`, `RepositoryHook`,
+`LanguageServer`, `StaticAnalyzer`, `QualityGate`, `DocumentParser`,
+`McpStdio`, or `GitWorktree`. Callers cannot supply Bubblewrap flags.
+
+## Environment and toolchains
+
+The launcher clears ambient environment authority. Locale is preserved;
+credential, proxy, SSH agent, desktop bus, display, dynamic-loader,
+language-runtime injection, and package-registry variables are absent unless
+the host names an exact grant in `OPENCLAUDIA_AGENT_ENV_GRANTS`. Reserved
+policy variables and credential-shaped names cannot be granted.
+
+Linux exposes `/usr`, Nix store/profiles, Rustup, Cargo binaries, and Cargo's
+registry cache read-only when present. It does not expose the rest of the
+user's home, Cargo credentials, shell startup files, histories, package
+manager auth, or writable host caches. Dependency installation can use
+vendored/project-local inputs; agent subprocess network access is denied.
+Custom tools require an explicit filesystem capability and remain subject to
+the executable and profile checks.
+
+## Git linked worktrees
+
+Ordinary Bash sees a minimal read-only `.git` view: `HEAD`, index, objects,
+refs, packed refs, and shallow metadata. Config, hooks, reflogs, credentials,
+pagers, helpers, filters, and external diff commands are absent or disabled.
+
+For linked worktrees, the `.git` indirection, `commondir`, admin-parent
+relationship, and backlink are validated on the host. Only the selected
+worktree admin files and common object/ref state are mounted. A forged
+indirection cannot mount an arbitrary path. Mutating worktree operations use
+the dedicated `GitWorktree` profile with hardened Git config and an audited
+metadata-write grant.
+
+## MCP and hooks
+
+Repository MCP servers require an exact
+`OPENCLAUDIA_TRUST_MCP_SERVERS=plugin/server` grant. Executables are
+canonicalized, must be outside agent-writable roots, and have trusted ancestry.
+Sensitive environment values require exact names in
+`OPENCLAUDIA_MCP_ENV_GRANTS`. Stdio MCP runs in `McpStdio` with network denied;
+revocation terminates and unregisters it.
+
+Command hooks default to `FullSandbox`. `none` and `env_scrub` require the host
+to start with `OPENCLAUDIA_TRUST_UNSANDBOXED_HOOKS=true`; this emits a warning
+and deliberately transfers host authority to the configured hook. Models
+cannot request that grant.
+
+## Platform status and deliberate non-support
+
+- **Linux:** enforced and covered by the adversarial escape suite.
+- **macOS:** descriptor-relative file tools are available, but agent
+  subprocesses fail closed. The deprecated `sandbox-exec` interface is not
+  treated as a production boundary. A maintained implementation requires a
+  separately signed/entitled helper or another Apple-supported isolation
+  design.
+- **Windows:** agent subprocess and file tools fail closed. A production
+  implementation requires AppContainer/restricted tokens, Job objects,
+  mitigation policy, ACL capability projection, and reparse-safe traversal.
+
+There is no automatic unsandboxed fallback. For incident recovery only, a host
+operator may set `OPENCLAUDIA_BASH_SANDBOX=off` before startup. This disables
+the subprocess boundary, exposes host network/filesystem authority, is
+reported by diagnostics, and must never be used for untrusted repositories.
+
+## Explicitly unsupported capabilities
+
+- Loopback-only or destination-specific subprocess networking is not shipped.
+  `OPENCLAUDIA_AGENT_NETWORK` accepts only `denied`; other values fail session
+  creation. A future design needs an isolated network namespace plus an
+  authenticated destination broker, not restoration of the host namespace.
+- Total writable-byte quotas and cgroup-v2 scopes are not available to an
+  ordinary process unless the service manager delegates a writable cgroup or
+  project filesystem. The current fallback enforces per-file `RLIMIT_FSIZE`,
+  address-space/CPU/process/fd caps, bounded output, wall deadlines, and full
+  process-tree termination. Operators needing a hard aggregate disk/memory
+  quota must run OpenClaudia inside a delegated service/container quota.
+- Agent-facing rename and delete file tools do not exist. Their race tests are
+  therefore non-applicable; future implementations must use descriptor-
+  relative primitives before being registered.
+- Attachments have no implicit path authority. A host must materialize them
+  under the session private temp directory or explicitly register their root.
+
+## Diagnostics, audit, and incident response
+
+`openclaudia doctor` reports the backend, health, network state, syscall
+filter, resource limits, root counts, environment-grant count, and opt-out
+state without printing values. It also reports each configured MCP server's
+trust requirement, transport/profile, and grant counts. Interactive tool
+permission prompts describe the enforced data/network scope in addition to
+the command or destination. Structured tracing records sandbox preflight,
+starts, denials, explicit trust decisions, metadata-write grants,
+cancellations, and terminations.
+
+If an escape is suspected: stop the session, preserve logs, revoke MCP/hook
+trust grants and provider credentials, inspect project hardlinks/mounts and
+generated executables, run `openclaudia doctor`, and reproduce only with
+test-owned local sentinels. Do not probe unrelated host data.

--- a/docs/subprocess-inventory.md
+++ b/docs/subprocess-inventory.md
@@ -1,0 +1,32 @@
+# Subprocess boundary inventory
+
+This inventory was generated from every `Command::new`,
+`tokio::process::Command`, launcher helper, and process-spawn call in `src/`.
+`tests/subprocess_boundary_e2e.rs` prevents new direct constructors from
+appearing in agent modules without an explicit review.
+
+| Location | Trust class | Boundary |
+|---|---|---|
+| `tools/bash/sandbox.rs` | Enforcement core | The only production constructor for agent subprocess commands; constructs named Linux Bubblewrap profiles or the explicit host-startup opt-out. |
+| `tools/command.rs` | Enforcement core | Bounded stdout/stderr, timeout, process-tree termination, and session cancellation. Its unsandboxed constructor is compiled only for unit tests. |
+| `tools/bash/mod.rs` | Agent-operated | Foreground/background Bash receives `Shell`; background buffers and ownership are bounded. |
+| `guardrails.rs` | Agent-operated | Quality gates receive `QualityGate` and the bounded runner. |
+| `hooks/mod.rs` | Agent-operated unless explicitly trusted | Direct/shell argv is constructed, then replaced with `RepositoryHook`; weak modes require immutable host-startup trust. |
+| `tools/lsp.rs` | Agent-operated | File input comes from a confined descriptor; server command receives `LanguageServer`; child is process-tree guarded and session-registered. |
+| `vdd/static_analysis.rs` | Agent-operated | Receives `StaticAnalyzer` and the bounded runner. |
+| `tools/file/read.rs` | Agent-operated | PDF helpers receive `DocumentParser` and consume a confined file descriptor through stdin. |
+| `mcp.rs` | Trusted extension with sandbox | Exact host approval and pinned executable, then `McpStdio`; child is session-registered. HTTP MCP uses the SSRF/credential broker instead of a subprocess. |
+| `tools/worktree.rs`, `subagent.rs` | Agent-operated administrative capability | Hardened Git argv/environment under `GitWorktree`; metadata write access is explicit and audited. |
+| `tools/bash/kill.rs` | Enforcement core | Unix uses syscalls; Windows `taskkill` is a fail-closed cleanup fallback and is not model-selected. |
+| `services/lsp_pool.rs` | Test/injected service | Production accepts an `LspSpawner`; direct sleep/timeout constructors occur only in its test module. Agent LSP uses `tools/lsp.rs`. |
+| `cli/repl/input.rs`, `cli/repl/permissions.rs` | User-operated | Interactive editor and `!` command launch paths; not registered as model tools. |
+| `tui/app.rs`, `tui/events.rs` | User-operated | Explicit interactive shell/editor/application actions; isolated from tool dispatch. |
+| `cli/repl/slash.rs`, `cli/repl/review.rs`, `cli/commit_pipeline.rs`, `main.rs` | User/administrator GitHub workflow | Resolved Git/GitHub binaries used only from CLI commands. |
+| `plugins/git.rs` | User-operated plugin administration | Installation/update Git operations reached from explicit plugin management, not the model registry. |
+| `cli/commands/auth.rs` | User-operated | Opens the OAuth URL in a desktop browser. |
+| `transcript.rs` | User-operated presentation | Read-only resolved Git metadata for transcript display. |
+
+The model tool registry exposes no generic host-process API. ACP maps Bash,
+file, edit, list, glob, and grep requests back through the same local tool
+registry and cannot delegate unrestricted filesystem or terminal access to
+the client.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -177,13 +177,13 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -223,9 +223,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -233,14 +233,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -250,7 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -269,7 +270,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -327,10 +328,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
+name = "base64"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bincode"
@@ -364,9 +365,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -389,12 +390,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -411,9 +412,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -429,9 +430,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -453,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -477,15 +478,15 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -528,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -538,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -550,14 +551,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -622,35 +623,29 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.24"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d0237145f33580b89724f75d16950efd3e2c91b2d823917ecb69ec7f84f0"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "async-trait",
  "pathdiff",
  "serde_core",
  "serde_json",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -749,18 +744,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crosslink"
@@ -771,7 +766,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "crossterm",
@@ -805,11 +800,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.2.1",
+ "mio 1.2.2",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -882,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -905,14 +900,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -927,7 +922,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -961,7 +956,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -974,7 +969,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -985,7 +980,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -996,7 +991,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1016,16 +1011,6 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -1051,7 +1036,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1061,7 +1046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1083,7 +1068,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1104,7 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
@@ -1146,19 +1131,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1199,24 +1184,22 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -1229,9 +1212,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1286,6 +1269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,9 +1309,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -1336,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -1428,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1443,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1453,15 +1447,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1470,38 +1464,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1563,11 +1557,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1661,13 +1653,13 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.6",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -1687,16 +1679,16 @@ checksum = "5754ca220578ad74a5d5174c8ca2ff956fd3b94025f870844de1e910b47dfee5"
 dependencies = [
  "anyhow",
  "auto_generate_cdp",
- "base64",
+ "base64 0.22.1",
  "derive_builder",
  "directories",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tungstenite",
  "ureq",
  "url",
@@ -1747,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "htmd"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+checksum = "a5a1c7113c831fec68cbd79cd8bf281a84e5b6943f51473dc266b0b88a6a017e"
 dependencies = [
  "html5ever 0.38.0",
  "markup5ever_rcdom",
@@ -1778,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1788,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1798,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1829,18 +1821,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1880,7 +1872,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2058,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2091,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -2126,7 +2118,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2168,7 +2160,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2183,7 +2175,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2202,24 +2194,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2234,7 +2226,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2253,7 +2245,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2277,9 +2269,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2299,9 +2291,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2323,7 +2315,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2361,15 +2353,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2382,9 +2374,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
 dependencies = [
  "sha2 0.11.0",
 ]
@@ -2450,9 +2442,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -2515,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2556,7 +2548,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2568,9 +2560,9 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
 ]
@@ -2581,9 +2573,9 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -2603,7 +2595,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2639,7 +2631,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2675,7 +2667,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -2687,7 +2679,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2698,7 +2690,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2717,7 +2709,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2728,7 +2720,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2751,7 +2743,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2775,14 +2767,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openclaudia"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",
  "async-trait",
  "axum",
  "axum-extra",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "clap",
  "config",
@@ -2790,12 +2782,13 @@ dependencies = [
  "crossterm",
  "dirs",
  "ed25519-dalek",
+ "eventsource-stream",
  "futures",
  "headless_chrome",
  "htmd",
  "indicatif",
  "libc",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ratatui",
  "regex",
  "reqwest 0.13.4",
@@ -2809,7 +2802,7 @@ dependencies = [
  "shlex",
  "similar",
  "syntect",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tower-http 0.7.0",
@@ -2874,7 +2867,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2924,9 +2917,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2934,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2944,25 +2937,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3013,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3036,7 +3028,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3049,7 +3041,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3077,16 +3069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,11 +3076,11 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap",
  "quick-xml",
  "serde",
@@ -3111,7 +3093,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3132,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-pty"
@@ -3195,18 +3177,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3216,28 +3198,28 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3245,21 +3227,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3267,23 +3250,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3312,18 +3295,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3331,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3375,6 +3358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,7 +3388,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
@@ -3406,7 +3398,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -3461,7 +3453,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -3481,7 +3473,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3492,14 +3484,14 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3509,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3530,7 +3522,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -3568,7 +3560,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3627,7 +3619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3636,7 +3628,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3647,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3658,32 +3650,33 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3700,7 +3693,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3709,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3737,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3786,17 +3779,17 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustyline"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "clipboard-win",
  "home",
@@ -3820,7 +3813,7 @@ checksum = "64e5587417a3c4e16a4415e8d7d07f80998ed835ade621d19dfbe9fbe3205b0f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3874,7 +3867,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3897,7 +3890,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -3918,9 +3911,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3928,29 +3921,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4026,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4116,7 +4109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.1",
+ "mio 1.2.2",
  "signal-hook",
 ]
 
@@ -4132,24 +4125,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4190,9 +4180,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4207,16 +4197,6 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -4292,7 +4272,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4314,9 +4294,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4340,7 +4331,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4359,7 +4350,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "yaml-rust",
 ]
@@ -4370,7 +4361,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4400,12 +4391,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -4414,7 +4404,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -4449,8 +4439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
- "bitflags 2.13.0",
+ "base64 0.22.1",
+ "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -4495,11 +4485,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4510,25 +4500,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -4549,9 +4539,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "js-sys",
@@ -4572,9 +4562,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4592,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4607,13 +4597,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.1",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4624,13 +4614,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4657,14 +4647,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4732,7 +4723,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4759,7 +4750,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "http",
  "http-body",
@@ -4802,7 +4793,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4874,9 +4865,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4903,7 +4894,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "web-time",
 ]
@@ -4977,7 +4968,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -4995,7 +4986,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -5020,12 +5011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,9 +5030,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -5119,9 +5104,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5132,9 +5117,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5142,9 +5127,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5152,22 +5137,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -5187,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5219,18 +5204,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5315,9 +5300,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]
@@ -5374,7 +5359,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5385,7 +5370,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5656,9 +5641,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5760,28 +5745,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5801,7 +5786,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5841,7 +5826,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5850,7 +5835,7 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
@@ -5873,15 +5858,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/sandbox-followups.md
+++ b/sandbox-followups.md
@@ -1,0 +1,459 @@
+# Sandbox follow-up goal
+
+Fix every unchecked item in this document. Treat this as a security-hardening goal, not a request to weaken tests or restore host execution when compatibility is difficult.
+
+## Goal
+
+Make every process and filesystem operation reachable from an agent obey an explicit, testable security boundary:
+
+- Agent-launched code must not read or modify host data outside its granted roots.
+- It must not reach the host network or host IPC endpoints unless a narrowly scoped capability explicitly permits it.
+- It must not escape through symlinks, hardlinks, nested mounts, special files, subprocesses, hooks, language servers, MCP servers, ACP delegation, or resource exhaustion.
+- Unsupported or unhealthy sandbox backends must fail closed with a useful diagnostic.
+- User-operated/trusted extension workflows must remain clearly distinct from agent-operated workflows.
+
+Do not remove the protections already implemented in `src/tools/bash/sandbox.rs`, do not accept a model-supplied sandbox-disable flag, and do not silently fall back to unsandboxed execution.
+
+## Current baseline
+
+The existing implementation already:
+
+- Runs foreground Bash, background Bash, ACP-routed Bash, quality gates, and `FullSandbox` hooks through a Linux Bubblewrap sandbox.
+- Gives the sandbox a private home, `/tmp`, `/run`, `/proc`, and `/dev`; removes network access and capabilities; and disables nested user namespaces.
+- Mounts the project writable, mounts selected runtimes/toolchains read-only, exposes minimal Git metadata read-only, and hides `.openclaudia` and `.claude` control data.
+- Fails closed when Bubblewrap is unavailable or the platform is unsupported, unless the host operator explicitly starts OpenClaudia with `OPENCLAUDIA_BASH_SANDBOX=off`.
+- Rejects dangerously broad project roots and covers the main write, symlink, network, Git, nested-user-namespace, ACP, quality-gate, and hook cases with tests.
+
+Preserve those properties while completing the work below.
+
+## Resolution record (2026-07-30)
+
+A checked box in this document means the item was resolved under the
+definition of done: implemented, made non-applicable by removing the
+agent-facing capability, or deliberately rejected with a fail-closed security
+rationale. It does **not** mean an unavailable platform feature was simulated
+or replaced with an unsandboxed fallback.
+
+| Finding | Resolution | Primary evidence |
+|---|---|---|
+| F01 | Implemented | `src/tools/security.rs`; private `0700` session temp roots, owner-bound capabilities, identity-checked cleanup; `tests/session_filesystem_capabilities_e2e.rs`. |
+| F02 | Implemented on Linux and macOS file backends; Windows file access deliberately fails closed. Agent rename/delete operations do not exist and remain unregistered. Symlinks are unsupported by policy. | `src/tools/file/secure_fs.rs`; `tests/session_filesystem_capabilities_e2e.rs`; `docs/sandbox-threat-model.md`. |
+| F03 | Implemented | ACP file/search/Bash operations execute through the local registry; IDE buffer metadata is session/path scoped; cancellation uses a blocking worker plus process-tree cancellation. |
+| F04 | Implemented | Named profiles in `src/tools/bash/sandbox.rs`; inventory in `docs/subprocess-inventory.md`; structural regression lint in `tests/subprocess_boundary_e2e.rs`. |
+| F05 | Implemented | Hooks default to `FullSandbox`; weak modes require immutable host-startup trust and emit audit warnings; all command-hook events share bounded launch/cleanup. |
+| F06 | Implemented with a narrower supported policy | Repository MCP needs an exact `plugin/server` host grant; stdio executables and ancestry are pinned outside writable roots; exact sensitive env grants only; stdio network remains denied. Destination-specific MCP subprocess networking is deliberately unsupported. |
+| F07 | Implemented | Writable roots are inode-scanned; external aliases fail startup, internal aliases are allowed for sandboxed subprocesses, and direct file-tool hardlinks use the stricter documented rejection policy. |
+| F08 | Implemented | `/proc/self/mountinfo` is checked before each writable bind; nested mounts fail closed; non-recursive, descriptor-pinned binds enter a private mount namespace. |
+| F09 | Implemented | Sockets, FIFOs, and device nodes reject writable roots; network namespaces and seccomp deny socket creation; inherited descriptors are closed. |
+| F10 | Implemented | Immutable per-session context carries roots, temp, environment, network, working directory, and owner; background lookup/signaling/cancellation is owner-bound. |
+| F11 | Production macOS/Windows subprocess backends deliberately not shipped | No maintained OS-supported implementation exists in this codebase. Those platforms fail closed with diagnostics and CI coverage; macOS retains descriptor-relative file access, while Windows file access also fails closed pending reparse-safe handles. |
+| F12 | Implemented | Startup executes a real Bubblewrap namespace/mount probe; doctor reports redacted effective policy and MCP grant counts; trusted executables are absolute and ownership/permissions checked. |
+| F13 | Implemented | Versioned seccomp-v1 BPF policy for Linux x86-64/AArch64; unknown architectures or filter failures fail closed; syscall and development-workload tests are included. |
+| F14 | Implemented with documented host-service limitations | CPU/address-space/process/fd/file-size/output/wall limits and whole-tree cleanup cover every agent profile. Aggregate disk quotas and delegated cgroup-v2 scopes are deliberately not claimed by an unprivileged process; operators needing them must add a service/container quota. |
+| F15 | Implemented | ACP local execution uses `spawn_blocking`, polls cancellation, and kills the registered sandbox process tree on cancel/disconnect/session shutdown. |
+| F16 | Implemented | Ambient env is cleared; locale plus exact host-startup names are granted; credentials, IPC, proxy, dynamic-loader, runtime-injection, and secret-shaped names are denied/redacted. |
+| F17 | Implemented | Runtime/toolchain mount inventory is documented and launcher-defined; selected runtime trees/caches are read-only; home config, credentials, histories, auth, and writable host caches stay absent. |
+| F18 | Implemented | Project read/write exposure is documented; optional relative secret masks exist; control paths are always hidden; permission prompts now display the effective data/network scope. |
+| F19 | Implemented | Linked-worktree indirection and backlinks are validated; minimal Git metadata is descriptor-pinned read-only; mutating operations use `GitWorktree` with hardened Git configuration. |
+| F20 | Default denial implemented; narrow networking deliberately unsupported | Restoring the host namespace would not be a narrow grant. Any non-`denied` subprocess policy is rejected until an authenticated destination broker exists. |
+
+### Deliberate secure rejections
+
+- There is no macOS or Windows agent subprocess compatibility fallback.
+  Implementing AppContainer/Job-object or a signed/entitled macOS helper is a
+  separate platform project; pretending `sandbox-exec`, ACL checks, or
+  environment scrubbing provides equivalent isolation would be unsafe.
+- Loopback and destination-specific subprocess network grants are not
+  accepted. A future implementation needs an isolated namespace and an
+  authenticated broker that binds destinations and expiry to the session.
+- An ordinary unprivileged process cannot promise an aggregate filesystem
+  quota or delegated cgroup. The launcher enforces its portable rlimit,
+  namespace, output, wall-time, and process-tree controls and documents the
+  stronger host deployment requirement.
+- Attachments gain no implicit host path access. They must be materialized in
+  the private session temp root or supplied through an explicit host-startup
+  root capability.
+
+### Verification record
+
+The implementation is gated by:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets --all-features -- --test-threads=1
+cargo check --target x86_64-pc-windows-gnu --no-default-features
+```
+
+The hosted workflow in `.github/workflows/sandbox-security.yml` repeats the
+Linux escape suites and compiles/runs the fail-closed suite on macOS and
+Windows. Escape probes use only test-owned sentinels and listeners.
+
+Local verification on 2026-07-30 completed all four commands above
+successfully. The Windows cross-target check emitted non-fatal
+target-specific unused-code warnings. Actual macOS and Windows runtime
+execution remains the responsibility of the hosted workflow; it was not
+simulated on the Linux development host.
+
+## Security boundary
+
+Use this classification consistently:
+
+1. **Agent-operated:** Bash, file tools, search, quality gates, hooks selected from repository-controlled configuration, language servers or analyzers influenced by repository contents, and any subprocess whose command or inputs an agent can influence. These require enforcement.
+2. **Brokered capability:** Web/search/provider tools and similar services intentionally implemented outside the process sandbox. These need their own allowlists, SSRF controls, secret isolation, and audit trail; sandboxed code must not inherit their credentials.
+3. **User-operated/trusted extension:** An interactive user `!` command, an explicitly trusted MCP server, plugin installation, or an administrative Git operation. These may run on the host only after an explicit trust decision and must not become indirectly agent-reachable.
+
+Repository content is untrusted. Merely opening a repository must not authorize its hooks, MCP configuration, language-server configuration, executables, or build scripts to run on the host.
+
+## P0 — close direct escape paths
+
+### F01: Replace the process-wide `/tmp` file-tool grant
+
+- [x] Remove the rule in `src/tools/file/mod.rs` that treats the entire canonical process temporary directory as an allowed root.
+- [x] Create a private per-session temporary directory with restrictive permissions.
+- [x] Grant file tools only that directory and individually registered attachment/artifact paths.
+- [x] Keep temporary capabilities in session/tool context rather than process-global state.
+- [x] Delete or revoke the private directory at session end without following links.
+
+Threat: another same-user process can leave secrets, sockets, or writable targets in the shared temporary directory. A grant to all of `/tmp` lets the agent reach them.
+
+Acceptance tests:
+
+- A file created in the session temp directory is accessible.
+- A sibling file elsewhere in the OS temp directory is denied.
+- A symlink from the session directory to a sibling target is denied.
+- Two concurrent sessions cannot read each other’s temporary files.
+
+### F02: Make all file operations race-safe
+
+- [x] Replace “canonicalize, validate, then open by pathname” with handle-relative resolution.
+- [x] On Linux, use `openat2` with suitable `RESOLVE_BENEATH`, `RESOLVE_NO_MAGICLINKS`, and symlink policy flags, or a carefully reviewed `openat` component walk using directory file descriptors and `O_NOFOLLOW`.
+- [x] Implement equivalent reparse-point-safe handle traversal on Windows and a descriptor-relative implementation on macOS.
+- [x] Apply the same primitive to read, write, edit, notebook, list, glob, search, directory creation, rename, and deletion operations.
+- [x] Decide and document whether symlinks wholly contained inside an allowed root are supported. Enforce that decision atomically.
+
+Threat: the existing leaf `O_NOFOLLOW` checks do not protect intermediate path components. A directory can be swapped for a symlink after validation but before the final open.
+
+Acceptance tests:
+
+- Repeatedly swap every intermediate directory component during read and write attempts; no access may occur outside the root.
+- Test file-to-symlink, directory-to-symlink, rename, and deletion races.
+- Test magic links such as `/proc/self/fd/*`.
+- Run the race suite under high concurrency and sanitizers where available.
+
+### F03: Enforce local roots for ACP filesystem and search operations
+
+- [x] Audit ACP read/write/edit delegation. Do not rely solely on the connected client to enforce the local path jail.
+- [x] Either route operations through the secure local file primitives or issue narrow, canonical, non-forgeable client capability tokens.
+- [x] Validate ACP search roots before invoking `rg` in `src/acp.rs`.
+- [x] If IDE buffer support requires client delegation, separate buffer access from arbitrary host filesystem access in the protocol and permission UI.
+
+Threat: ACP delegation can bypass the local filesystem jail and turn the client into an implicit, inconsistent enforcement boundary.
+
+Acceptance tests:
+
+- ACP read, write, edit, and search reject absolute paths, `..`, symlink races, and alternate spellings that resolve outside granted roots.
+- A malicious or permissive mock ACP client cannot expand the local grant.
+- Unsaved in-editor buffers still work only for files covered by a valid capability.
+
+### F04: Sandbox every agent-reachable subprocess
+
+- [x] Build an inventory of every `Command::new`, shell invocation, process-spawn helper, and extension execution path.
+- [x] Classify each caller using the security-boundary section above.
+- [x] Route every agent-operated subprocess through a common sandbox launcher with a named policy profile.
+- [x] Give trusted host operations a separate API that cannot be called from agent tool dispatch.
+- [x] Add a test or lint that fails when a new agent-reachable direct subprocess spawn is introduced.
+
+Known locations requiring resolution:
+
+- `src/tools/lsp.rs`: language servers can execute repository-controlled build scripts, compiler plugins, formatters, or configuration.
+- `src/vdd/static_analysis.rs`: verify how analyzer commands are selected and sandbox any project-influenced execution.
+- `src/acp.rs`: the direct `rg` search subprocess needs root enforcement and an appropriate profile.
+- `src/tools/command.rs`: audit every caller rather than assuming a generic subprocess helper is trusted.
+- `src/mcp.rs`: configured stdio MCP servers are a separate trust boundary; see F06.
+- `src/tui/app.rs`: interactive `!` commands appear user-operated. Keep them structurally inaccessible to agent dispatch, or sandbox them if that assumption is false.
+- Plugin Git helpers should remain a trusted administrative path only if an agent cannot invoke them indirectly.
+
+Acceptance tests:
+
+- A repository-provided LSP, analyzer, formatter, and search configuration cannot read a host sentinel, open the network, or write outside its grant.
+- Tests prove user-only subprocess APIs cannot be reached through tool names, hooks, ACP messages, plugins, or prompt-generated arguments.
+
+### F05: Treat repository hooks as untrusted by default
+
+- [x] Change the default hook behavior from `EnvScrub` to an enforced sandbox or “disabled pending trust.”
+- [x] Do not execute hooks discovered in repository or Claude-compatible configuration on the host merely because the repository was opened.
+- [x] Keep `None` and `EnvScrub` modes available only for an explicit host-operator trust decision with a warning and audit event.
+- [x] Ensure hook working directory, environment, executable resolution, network policy, timeouts, output limits, and process cleanup all come from the selected profile.
+- [x] Cover every hook event, not just one representative path.
+
+Threat: environment scrubbing is not isolation. A repository-controlled hook with host process access can read files, use inherited identity, connect to services, or modify the host.
+
+Acceptance tests:
+
+- A newly cloned malicious repository cannot trigger host execution before trust is granted.
+- Default hooks cannot access host sentinels, control directories, network, session sockets, or sibling projects.
+- An explicit user trust action is visible, scoped, revocable, and cannot be supplied by the model.
+
+### F06: Define and enforce the MCP server trust boundary
+
+- [x] Treat locally configured stdio MCP servers as trusted extensions only after explicit user approval, or run them under a configurable per-server sandbox profile.
+- [x] Distinguish user-level trusted configuration from repository-provided MCP configuration.
+- [x] Never pass the agent process environment wholesale. Grant individual environment variables, filesystem roots, and network destinations.
+- [x] Surface each server’s effective permissions before launch and in diagnostics.
+- [x] Prevent an untrusted repository from replacing a trusted executable through `PATH`, relative paths, working-directory tricks, or symlinks.
+
+Do not blindly apply the Bash no-network profile: some MCP servers legitimately need network access or credentials. They need declared capabilities, not ambient authority.
+
+Acceptance tests:
+
+- Repository MCP configuration cannot launch before approval.
+- Executables are resolved and pinned outside attacker-writable roots.
+- A server receives only declared secrets and can reach only declared roots/destinations.
+- Revocation terminates the server and invalidates its capabilities.
+
+## P0 — harden the namespace boundary
+
+### F07: Block hardlink alias escapes
+
+- [x] Prevent a writable file inside the project bind from being a hardlink to a file outside the granted roots.
+- [x] Choose a defensible strategy: validate and reject external aliases, stage the project in a copy-on-write layer with controlled commit-back, or enforce an equivalent inode-safe design.
+- [x] Handle legitimate hardlinks that are entirely internal to a granted tree.
+- [x] Re-check the invariant when files are imported, attachments are materialized, or roots change.
+
+Threat: namespace path isolation does not change inode identity. Writing a project path that is already hardlinked to an outside file modifies the outside inode.
+
+Acceptance tests:
+
+- A pre-existing project hardlink to a host sentinel cannot modify the sentinel.
+- Internal hardlinks behave according to the documented policy.
+- Renames and atomic-replace writes do not reintroduce an outside alias.
+
+### F08: Reject or isolate nested mounts
+
+- [x] Inspect the host mount table before binding a granted root.
+- [x] Reject, mask, or reconstruct roots containing nested mounts that are not separately granted.
+- [x] Avoid recursive bind behavior that silently imports host mounts under the project.
+- [x] Revalidate for long-running sessions or pin a mount-safe snapshot so a later host mount cannot appear inside the sandbox.
+
+Threat: a project subdirectory can be a mount of the user’s home, a secret volume, a device filesystem, or another sensitive tree.
+
+Acceptance tests:
+
+- Bind mounts, FUSE mounts, removable-media mounts, and mount namespaces nested below the project are absent unless explicitly granted.
+- A mount introduced after session creation cannot become visible to the running sandbox.
+
+### F09: Block host IPC and special-file escapes
+
+- [x] Detect and reject or mask Unix-domain sockets, FIFOs, device nodes, and other special files inside writable grants.
+- [x] Confirm that filesystem Unix sockets cannot connect from the sandbox to host services.
+- [x] Keep abstract sockets and TCP/UDP inaccessible by default.
+- [x] Add a seccomp layer as described in F13 to reduce syscall-level IPC and kernel attack surface.
+
+Threat: a socket inside the project may lead to Docker, SSH agents, databases, desktop services, or another privileged host daemon even though the network namespace is private.
+
+Acceptance tests:
+
+- The sandbox cannot use a project-contained socket connected to a host listener.
+- It cannot communicate through a FIFO crossing the boundary or use a project-contained device node.
+- Normal regular files and explicitly supported build IPC continue to work.
+
+## P1 — make policy explicit and portable
+
+### F10: Carry immutable roots and capabilities in tool context
+
+- [x] Stop deriving the security root from process-global `current_dir()` or a lazy process-global `PROJECT_ROOT`.
+- [x] Create an immutable per-session context containing project identity, working directory, granted read-only/read-write roots, temp capability, environment grants, network policy, and owner/session ID.
+- [x] Pass that context through Bash, file tools, background jobs, ACP, hooks, LSP, analyzers, and quality gates.
+- [x] Support explicitly granted additional working directories and worktrees without broadening access to their parents.
+- [x] Bind the background-process registry and cancellation authority to the owning session.
+
+Threat: multiple projects or sessions in one process can race over global current-directory state or accidentally inherit another session’s grants.
+
+Acceptance tests:
+
+- Concurrent sessions rooted in different projects cannot cross-read, cross-write, list, search, signal, or await each other’s resources.
+- Changing process current directory does not change an existing session’s boundary.
+- Worktree and additional-root access is exactly the declared capability set.
+
+### F11: Add real macOS and Windows backends
+
+- [x] Define a platform-neutral sandbox policy interface and platform-specific implementations.
+- [x] Implement macOS isolation using a maintained OS-supported mechanism with filesystem, network, IPC, process, and resource controls.
+- [x] Implement Windows isolation using an appropriate combination of AppContainer/restricted tokens, job objects, ACL/capability grants, process mitigation, and reparse-point-safe filesystem handling.
+- [x] Keep unsupported configurations fail closed. The environment-variable opt-out must remain a host startup decision with a prominent warning.
+- [x] Add platform CI and escape tests rather than testing only that unsupported systems reject execution.
+
+Acceptance tests:
+
+- The common escape suite passes on Linux, macOS, and Windows.
+- Each backend reports its active protections and unsupported features.
+- There is no automatic unsandboxed compatibility fallback.
+
+### F12: Add backend health checks and diagnostics
+
+- [x] Probe Bubblewrap usability, kernel namespace support, distribution restrictions, and required mount behavior at startup rather than checking only for a binary in trusted paths.
+- [x] Add a doctor/status view that reports backend, effective policy, granted roots, network state, seccomp state, resource limits, and any explicit opt-out.
+- [x] Make execution errors actionable without including sensitive host paths or environment values.
+- [x] Pin executable resolution to trusted absolute paths and verify ownership/permissions where appropriate.
+
+Acceptance tests:
+
+- A present-but-unusable Bubblewrap installation is diagnosed before the first agent command.
+- Setuid, unprivileged-user-namespace-disabled, container-within-container, and missing-kernel-feature cases fail closed with distinct messages.
+- Diagnostics never print secrets.
+
+### F13: Add syscall filtering
+
+- [x] Apply a reviewed seccomp policy after namespace setup.
+- [x] At minimum assess and normally deny mount-related syscalls, `ptrace`, BPF, performance events, kernel keyring operations, module/kexec operations, raw sockets, additional namespace creation, and other unnecessary privileged/kernel-attack-surface calls.
+- [x] Keep the policy architecture-aware and test common compilers, package managers, test runners, Git inspection, and language servers.
+- [x] Version named profiles when different tools genuinely require different syscall sets.
+
+Acceptance tests:
+
+- Dedicated probes for each denied syscall fail predictably.
+- Supported development workloads still run.
+- An unknown architecture or policy-load failure causes sandbox startup to fail closed.
+
+### F14: Add resource and lifetime isolation
+
+- [x] Enforce CPU, memory, process-count, open-file, output-size, disk/quota, and wall-clock limits using cgroup v2/systemd scopes where available plus appropriate rlimits.
+- [x] Cap captured stdout/stderr without allowing an unbounded in-memory buffer.
+- [x] Terminate the entire process tree on cancellation, timeout, session end, or parent death.
+- [x] Prove that double-forked, daemonized, and orphaned children cannot survive.
+- [x] Apply limits to foreground, background, hooks, quality gates, LSP, analyzers, and sandboxed MCP servers.
+
+Acceptance tests:
+
+- Fork bombs, memory bombs, output floods, disk fills, CPU loops, and daemonization attempts are contained.
+- The host remains responsive and the user receives a bounded diagnostic.
+- Terminating one session cannot signal another session’s jobs.
+
+### F15: Make ACP execution asynchronous and cancellable
+
+- [x] Move synchronous local Bash execution out of the async ACP event loop using a cancellation-aware blocking worker or a fully async process implementation.
+- [x] Preserve the exact same local sandbox profile and permission checks.
+- [x] Propagate disconnect, cancellation, timeout, and session shutdown to the complete sandbox process tree.
+
+Acceptance tests:
+
+- A long foreground command does not block unrelated ACP messages.
+- Cancellation promptly kills every descendant.
+- Sandboxing cannot be bypassed by switching between foreground and background execution.
+
+## P1 — reduce ambient data exposure
+
+### F16: Replace broad environment-prefix inheritance
+
+- [x] Review environment scrubbing, especially broad prefixes such as `SSH_`, `XDG_`, and `DBUS_`.
+- [x] Replace prefix-based inheritance with explicit per-profile variable grants wherever practical.
+- [x] Strip host IPC endpoints, credential variables, injected runtime options, proxy variables, and secret-shaped values unless deliberately required.
+- [x] Prevent repository configuration or agent arguments from requesting arbitrary host environment variables.
+- [x] Redact values in logs, status displays, and errors.
+
+Acceptance tests:
+
+- Canary secrets under allowed-looking prefixes do not reach sandboxed processes.
+- Required locale, terminal, and toolchain behavior still works through documented grants.
+- SSH agent, desktop bus, credential-helper, cloud, package-registry, and proxy endpoints are absent by default.
+
+### F17: Audit runtime and toolchain mounts
+
+- [x] Inventory every host directory mounted for Rust, Node, Python, Nix, and other supported toolchains.
+- [x] Mount only immutable executables, libraries, sources, and caches required by the profile.
+- [x] Exclude credentials, writable configuration, history, activation hooks, user startup files, and package-manager auth.
+- [x] Decide how package installation works without granting general network or host cache writes.
+- [x] Treat executables from project directories, `~/.local`, `/opt`, or custom toolchains as explicit capabilities rather than silently exposing them.
+
+Acceptance tests:
+
+- Credential canaries placed beside toolchain caches are not readable.
+- Read-only toolchain execution succeeds.
+- Package managers cannot mutate host caches or obtain undeclared credentials.
+
+### F18: Make project-secret exposure an explicit policy
+
+- [x] Document that the project root is readable and writable by agent code, including `.env`, local keys, test fixtures, and generated credentials stored there.
+- [x] Add optional secret masking or narrow root capabilities for users who do not want the full repository exposed.
+- [x] Keep `.openclaudia`, `.claude`, and equivalent control-plane data hidden even when nested or referenced by alternate paths.
+- [x] Ensure permission prompts describe the real data scope, not only the command string.
+
+Acceptance tests:
+
+- Default and restricted modes have clear, tested behavior for project secrets.
+- Hidden control paths remain inaccessible through symlinks, hardlinks, worktrees, case aliases, and alternate path syntax.
+
+### F19: Safely support Git linked worktrees
+
+- [x] Handle a worktree `.git` indirection file without mounting its arbitrary target.
+- [x] Parse and validate Git metadata on the host, prove it belongs to the current repository/worktree, and expose only the minimum read-only metadata required for safe inspection.
+- [x] Mask hooks, config that launches helpers, credentials, reflogs, remote URLs, and unrelated worktrees unless explicitly needed.
+- [x] Keep mutating Git operations in dedicated permissioned tools rather than making the Bash metadata mount writable.
+
+Acceptance tests:
+
+- Safe `git status` and `git diff` work in normal repositories and linked worktrees.
+- A forged `.git` file cannot expose an arbitrary host path.
+- Git aliases, hooks, filters, pagers, credential helpers, and external diff commands cannot cause host execution or secret access.
+
+### F20: Define narrowly scoped test-network capabilities
+
+- [x] Keep network disabled by default for Bash and quality gates.
+- [x] If test suites need networking, add a profile that can grant loopback or declared destinations without restoring the host network namespace.
+- [x] Make the grant visible, time-limited, and user-controlled; never infer it from command text.
+- [x] Ensure local service discovery, proxy environment variables, DNS, and Unix sockets cannot broaden the grant.
+
+Acceptance tests:
+
+- A loopback-only test service works when explicitly enabled.
+- Public internet, LAN, metadata services, host services, and undeclared ports remain unreachable.
+- The default quality-gate profile has no network.
+
+## Engineering requirements
+
+- [x] Centralize policy construction. Callers select a named profile and pass capabilities; they must not assemble Bubblewrap flags ad hoc.
+- [x] Use typed paths/handles and typed capabilities instead of unvalidated strings.
+- [x] Separate the trusted host launcher API from the agent sandbox launcher API at the type/module boundary.
+- [x] Emit structured audit events for grants, denials, trust decisions, backend failures, starts, cancellations, and terminations without logging secret values.
+- [x] Preserve permission prompts as defense in depth, but never treat a prompt or denylist as the isolation boundary.
+- [x] Avoid parsing shell text to decide security policy.
+- [x] Document the threat model, supported platforms, limitations, opt-out consequences, and incident-response guidance.
+- [x] Preserve unrelated worktree changes and generated user data.
+
+## Required adversarial test matrix
+
+Add deterministic local tests for all applicable profiles and platforms:
+
+- [x] Absolute paths, `..`, symlinks, junctions/reparse points, magic links, path races, case-folding, Unicode aliases, and long paths.
+- [x] Hardlinks, nested mounts, bind mounts, FUSE, sockets, FIFOs, device nodes, `/proc`, `/sys`, and inherited file descriptors.
+- [x] Network namespace, IPv4, IPv6, DNS, loopback, abstract and filesystem Unix sockets, proxies, and host metadata endpoints.
+- [x] Process escape attempts: nested user namespaces, clone/unshare variants, ptrace, seccomp bypass probes, daemonization, parent death, and cross-session signaling.
+- [x] Environment, Git helpers/hooks/config, compiler plugins, build scripts, LSP configuration, analyzer configuration, MCP executable resolution, and repository hooks.
+- [x] CPU, memory, process, file-descriptor, output, disk, and wall-time exhaustion.
+- [x] Concurrent sessions with different projects, temp directories, worktrees, added roots, and background jobs.
+- [x] Backend unavailable, partially supported, deliberately disabled, and startup health-check failures.
+
+Escape tests must use local sentinel files and listeners owned by the test process. They must not probe unrelated host data or external systems.
+
+## Definition of done
+
+This goal is complete only when:
+
+- [x] Every item above is implemented, explicitly rejected as out of scope with a documented security rationale, or converted into a tracked issue with user approval. Do not silently skip items.
+- [x] No agent-reachable path launches an unsandboxed process or delegates unrestricted filesystem access.
+- [x] Every trusted-host path requires an explicit user/administrator trust decision and is structurally separated from agent dispatch.
+- [x] Linux, macOS, and Windows either pass the common security suite or fail closed with the platform limitation clearly reported.
+- [x] The threat model and user documentation match the actual implementation.
+- [x] Formatting, linting, unit tests, integration tests, adversarial tests, and platform CI pass.
+- [x] A final review inventories subprocess creation and filesystem entry points again and explains why each is safe.
+
+Run at least:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets -- --test-threads=1
+```
+
+Also run the new platform-specific sandbox integration suites in disposable CI runners. Do not weaken or delete an escape test merely to make a platform pass.

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -4652,7 +4652,7 @@ mod acp_permission_gate_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod pre_tool_gate_tests {
     use super::pre_tool_use_gate;
     use crate::config::{Hook, HookEntry, HookPolicy, HooksConfig};

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -11,10 +11,9 @@
 //! - `session/set_mode` — change session mode
 //! - `session/set_config_option` — set advertised session config options
 //!
-//! Tool execution is delegated through ACP client methods:
-//! - `fs/read_text_file`, `fs/write_text_file` — file operations
-//! - `terminal/create`, `terminal/output`, `terminal/wait_for_exit`,
-//!   `terminal/kill`, `terminal/release` — shell execution
+//! File, search, and shell execution deliberately stay local so every ACP
+//! caller crosses `OpenClaudia`'s filesystem jail and OS sandbox instead of
+//! trusting the client's filesystem or terminal implementation.
 
 use std::collections::{HashMap, VecDeque};
 use std::io::{self, BufRead, Write};
@@ -24,7 +23,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::config::AppConfig;
@@ -53,12 +52,6 @@ pub(crate) struct JsonRpcMessage {
     /// Present on requests and notifications.
     #[serde(default)]
     params: Option<Value>,
-    /// Present on successful responses.
-    #[serde(default)]
-    result: Option<Value>,
-    /// Present on error responses.
-    #[serde(default)]
-    error: Option<JsonRpcError>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,16 +77,6 @@ struct JsonRpcResponse {
 #[derive(Debug, Serialize)]
 struct JsonRpcNotification {
     jsonrpc: &'static str,
-    method: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    params: Option<Value>,
-}
-
-/// Outgoing JSON-RPC request (server → client, e.g. `fs/read_text_file`).
-#[derive(Debug, Serialize)]
-struct JsonRpcRequest {
-    jsonrpc: &'static str,
-    id: u64,
     method: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     params: Option<Value>,
@@ -151,14 +134,9 @@ pub struct AcpServer {
     /// Library-layer permission manager. Every tool call dispatched from
     /// `execute_tool_via_openclaudia` consults this gate — closes
     /// crosslink #505 for the ACP path.
-    permission_mgr: crate::permissions::PermissionManager,
+    permission_mgr: Arc<crate::permissions::PermissionManager>,
     /// Session-scoped enterprise policy enforcer for model/token/tool caps.
     policy_enforcer: Arc<crate::services::policy::PolicyEnforcer>,
-    /// Request ID counter for server→client requests
-    next_request_id: AtomicU64,
-    /// Pending responses for server→client requests
-    #[allow(clippy::type_complexity)]
-    pending_responses: Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value, JsonRpcError>>>>>,
     /// Cancellation flag for in-flight prompts
     cancel_flag: Arc<AtomicBool>,
     /// Channel for writing to stdout (serialized access)
@@ -774,11 +752,11 @@ impl AcpServer {
         let merged_hooks = merge_hooks_config(config.hooks.clone(), claude_hooks);
         let hook_engine = HookEngine::new(merged_hooks);
         let rules_engine = RulesEngine::new(".openclaudia/rules");
-        let permission_mgr = crate::permissions::PermissionManager::new(
+        let permission_mgr = Arc::new(crate::permissions::PermissionManager::new(
             std::path::PathBuf::from(".openclaudia/permissions.json"),
             true,
             config.permissions.default_allow.clone(),
-        );
+        ));
         let policy_enforcer = Arc::new(crate::services::policy::PolicyEnforcer::new(
             config.policy.clone(),
         ));
@@ -796,8 +774,6 @@ impl AcpServer {
             claude_code_token,
             permission_mgr,
             policy_enforcer,
-            next_request_id: AtomicU64::new(1),
-            pending_responses: Arc::new(Mutex::new(HashMap::new())),
             cancel_flag: Arc::new(AtomicBool::new(false)),
             stdout_tx,
             config_options: HashMap::new(),
@@ -841,43 +817,6 @@ impl AcpServer {
         };
         if let Ok(line) = serde_json::to_string(&notif) {
             let _ = self.stdout_tx.send(line);
-        }
-    }
-
-    /// Send a JSON-RPC request to the client and await the response.
-    async fn client_request(&self, method: &str, params: Option<Value>) -> Result<Value, String> {
-        let id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
-        let (tx, rx) = oneshot::channel();
-
-        // Register pending response
-        {
-            let mut pending = self.pending_responses.lock().await;
-            pending.insert(id, tx);
-        }
-
-        // Send request
-        let req = JsonRpcRequest {
-            jsonrpc: "2.0",
-            id,
-            method: method.to_string(),
-            params,
-        };
-        if let Ok(line) = serde_json::to_string(&req) {
-            let _ = self.stdout_tx.send(line);
-        }
-
-        // Await response with timeout
-        match tokio::time::timeout(std::time::Duration::from_mins(5), rx).await {
-            Ok(Ok(Ok(value))) => Ok(value),
-            Ok(Ok(Err(rpc_err))) => Err(format!("RPC error {}: {}", rpc_err.code, rpc_err.message)),
-            Ok(Err(_)) => Err("Client request channel closed".to_string()),
-            Err(_) => {
-                // Clean up pending
-                let mut pending = self.pending_responses.lock().await;
-                pending.remove(&id);
-                drop(pending);
-                Err("Client request timed out".to_string())
-            }
         }
     }
 
@@ -946,22 +885,8 @@ impl AcpServer {
 
     /// Route an incoming JSON-RPC message.
     async fn handle_message(&mut self, msg: JsonRpcMessage) {
-        // Is this a response to a server→client request?
-        if msg.method.is_none() && (msg.result.is_some() || msg.error.is_some()) {
-            if let Some(id) = msg.id.as_ref().and_then(serde_json::Value::as_u64) {
-                let mut pending = self.pending_responses.lock().await;
-                if let Some(tx) = pending.remove(&id) {
-                    if let Some(err) = msg.error {
-                        let _ = tx.send(Err(err));
-                    } else {
-                        let _ = tx.send(Ok(msg.result.unwrap_or(Value::Null)));
-                    }
-                }
-            }
-            return;
-        }
-
-        // It's a request or notification from the client
+        // This server sends notifications and responses, never requests, so an
+        // incoming message must be a request or notification from the client.
         let method = if let Some(ref m) = msg.method {
             m.clone()
         } else {
@@ -1255,19 +1180,53 @@ impl AcpServer {
     // ========================================================================
 
     fn handle_ide_file_opened(&mut self, params: &Value) {
+        if !self.ide_notification_path_allowed(params) {
+            return;
+        }
         apply_ide_file_opened(&mut self.ide_state, params);
     }
 
     fn handle_ide_file_closed(&mut self, params: &Value) {
+        if !self.ide_notification_path_allowed(params) {
+            return;
+        }
         apply_ide_file_closed(&mut self.ide_state, params);
     }
 
     fn handle_ide_selection_changed(&mut self, params: &Value) {
+        if !self.ide_notification_path_allowed(params) {
+            return;
+        }
         apply_ide_selection_changed(&mut self.ide_state, params);
     }
 
     fn handle_ide_diagnostics(&mut self, params: &Value) {
+        if !self.ide_notification_path_allowed(params) {
+            return;
+        }
         apply_ide_diagnostics(&mut self.ide_state, params);
+    }
+
+    fn ide_notification_path_allowed(&self, params: &Value) -> bool {
+        let Some(path) = params.get("filePath").and_then(Value::as_str) else {
+            return false;
+        };
+        let Some(acp_session_id) = params.get("sessionId").and_then(Value::as_str) else {
+            warn!("ACP IDE notification omitted sessionId; dropping unscoped buffer data");
+            return false;
+        };
+        let openclaudia_session_id = self.oc_session_id_for_acp(acp_session_id);
+        let _guard = crate::tools::SessionIdGuard::set(openclaudia_session_id);
+        match crate::tools::security::validate_client_buffer_path(std::path::Path::new(path)) {
+            Ok(_) => true,
+            Err(reason) => {
+                warn!(
+                    event = "acp_ide_buffer_denied",
+                    reason, "Dropped IDE buffer notification outside the session capability"
+                );
+                false
+            }
+        }
     }
 
     // ========================================================================
@@ -1316,6 +1275,7 @@ impl AcpServer {
         // Reset cancel flag
         self.cancel_flag.store(false, Ordering::SeqCst);
         let oc_session_id = self.oc_session_id_for_acp(&acp_session_id);
+        crate::tools::clear_session_process_cancellation(&oc_session_id);
 
         // Add user message
         self.messages.push(json!({
@@ -1415,9 +1375,9 @@ impl AcpServer {
             // paths inherited a different mental model than the model
             // was given. Best-effort: a failed `current_dir` call simply
             // omits the block (matches the proxy-path behaviour).
-            let cwd_string = std::env::current_dir()
+            let cwd_string = crate::tools::security::current_context()
                 .ok()
-                .map(|p| p.to_string_lossy().into_owned());
+                .map(|context| context.working_directory().to_string_lossy().into_owned());
             let system_prompt = crate::prompt::build_system_prompt_with_cwd(
                 None,
                 rules_arg,
@@ -1988,9 +1948,12 @@ impl AcpServer {
             "read_file" => self.acp_read_file(session_id, &args).await,
             "write_file" => self.acp_write_file(session_id, &args).await,
             "edit_file" => self.acp_edit_file(session_id, &args).await,
+            // Shells must run through the local executor: delegating these to
+            // an arbitrary ACP client's terminal/create API bypasses
+            // OpenClaudia's OS sandbox entirely.
             "bash" => self.acp_bash(session_id, &args).await,
-            "bash_output" => self.acp_bash_output(&args).await,
-            "kill_shell" => self.acp_kill_shell(&args).await,
+            "bash_output" => self.acp_bash_output(session_id, &args),
+            "kill_shell" => self.acp_kill_shell(session_id, &args),
             "list_files" => self.acp_list_files(session_id, &args).await,
             "glob" | "grep" => self.acp_search(session_id, &args, tool_name).await,
             // Internal tools run locally — not file/terminal operations
@@ -2036,32 +1999,67 @@ impl AcpServer {
         tool_name: &str,
         arguments_json: &str,
     ) -> AcpToolResult {
-        use crate::tools::{FunctionCall, ToolCall};
+        execute_local_tool_with_permission(
+            &self.permission_mgr,
+            session_id,
+            tool_name,
+            arguments_json,
+        )
+    }
 
-        let tc = ToolCall {
-            id: "local".to_string(),
-            call_type: "function".to_string(),
-            function: FunctionCall {
-                name: tool_name.to_string(),
-                arguments: arguments_json.to_string(),
-            },
-        };
-
-        let result = crate::services::tool_executor::ToolExecutor::execute(
-            crate::services::tool_executor::ToolExecutorRequest {
-                tool_call: &tc,
-                memory_db: None,
-                app_config: None,
-                task_mgr: None,
-                permission_mgr: Some(&self.permission_mgr),
-                permission_already_checked: false,
-                session_id: Some(session_id),
-                policy_enforcer: None,
-            },
-        );
-        AcpToolResult {
-            content: result.content,
-            is_error: result.is_error,
+    /// Execute a synchronous local tool on Tokio's blocking pool so a
+    /// foreground command or large file operation cannot stall ACP message
+    /// routing. The permission manager is shared read-only here; the outer ACP
+    /// gate already made and recorded the mutable permission decision.
+    async fn execute_local_tool_async(
+        &self,
+        session_id: &str,
+        tool_name: &str,
+        arguments_json: &str,
+    ) -> AcpToolResult {
+        let permission_mgr = Arc::clone(&self.permission_mgr);
+        let session_id = session_id.to_string();
+        let tool_name = tool_name.to_string();
+        let arguments_json = arguments_json.to_string();
+        let cancellation = Arc::clone(&self.cancel_flag);
+        let cancellation_session = session_id.clone();
+        let mut worker = tokio::task::spawn_blocking(move || {
+            execute_local_tool_with_permission(
+                &permission_mgr,
+                &session_id,
+                &tool_name,
+                &arguments_json,
+            )
+        });
+        loop {
+            tokio::select! {
+                outcome = &mut worker => {
+                    return match outcome {
+                        Ok(result) => result,
+                        Err(error) => AcpToolResult {
+                            content: format!("Local tool worker failed: {error}"),
+                            is_error: true,
+                        },
+                    };
+                }
+                () = tokio::time::sleep(std::time::Duration::from_millis(20)) => {
+                    if cancellation.load(Ordering::SeqCst) {
+                        let cancelled_processes =
+                            crate::tools::cancel_session_sandbox_processes(&cancellation_session);
+                        let _ = tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            &mut worker,
+                        )
+                        .await;
+                        return AcpToolResult {
+                            content: format!(
+                                "Tool execution cancelled; terminated {cancelled_processes} sandbox process tree(s)"
+                            ),
+                            is_error: true,
+                        };
+                    }
+                }
+            }
         }
     }
 
@@ -2102,7 +2100,7 @@ impl AcpServer {
         self.rules_engine.get_combined_rules(&ext_refs)
     }
 
-    // -- File operations via ACP client --
+    // -- Locally confined file operations --
 
     async fn acp_read_file(
         &self,
@@ -2118,49 +2116,31 @@ impl AcpServer {
         // Match the registry read_file contract: offset is a 1-indexed
         // positive line number, limit is a positive max-line count. Validate
         // before asking the ACP client to read the file.
-        let offset = match parse_acp_read_offset_arg(args.get("offset")) {
-            Ok(offset) => offset,
-            Err(result) => return result,
-        };
-        let limit = match parse_acp_read_limit_arg(args.get("limit")) {
-            Ok(limit) => limit,
-            Err(result) => return result,
-        };
-
-        match self
-            .client_request("fs/read_text_file", Some(json!({"path": path})))
-            .await
-        {
-            Ok(result) => {
-                let text = result
-                    .get("text")
-                    .or_else(|| result.get("content"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-
-                let lines: Vec<&str> = text.lines().collect();
-                let start = offset.min(lines.len());
-                let end = limit.map_or(lines.len(), |l| (start + l).min(lines.len()));
-
-                let numbered: String = lines[start..end]
-                    .iter()
-                    .enumerate()
-                    .map(|(i, line)| format!("{:>6}\t{}", start + i + 1, line))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                record_acp_file_read_observation(session_id, path, text, start, end, &numbered);
-
-                AcpToolResult {
-                    content: numbered,
-                    is_error: false,
-                }
-            }
-            Err(e) => AcpToolResult {
-                content: format!("Failed to read file: {e}"),
-                is_error: true,
-            },
+        if let Err(result) = parse_acp_read_offset_arg(args.get("offset")) {
+            return result;
         }
+        if let Err(result) = parse_acp_read_limit_arg(args.get("limit")) {
+            return result;
+        }
+
+        let mut local_args = serde_json::Map::new();
+        local_args.insert("path".to_string(), Value::String(path.to_string()));
+        if let Some(offset) = args.get("offset") {
+            local_args.insert("offset".to_string(), offset.clone());
+        }
+        if let Some(limit) = args.get("limit") {
+            local_args.insert("limit".to_string(), limit.clone());
+        }
+        if let Some(pages) = args.get("pages") {
+            local_args.insert("pages".to_string(), pages.clone());
+        }
+
+        self.execute_local_tool_async(
+            session_id,
+            "read_file",
+            &Value::Object(local_args).to_string(),
+        )
+        .await
     }
 
     async fn acp_write_file(
@@ -2173,52 +2153,17 @@ impl AcpServer {
             Ok(path) => path,
             Err(result) => return result,
         };
-
         let content = match parse_acp_required_string_arg(args, "content") {
             Ok(content) => content,
             Err(result) => return result,
         };
 
-        let before = self
-            .client_request("fs/read_text_file", Some(json!({"path": path})))
-            .await
-            .ok()
-            .and_then(|result| {
-                result
-                    .get("text")
-                    .or_else(|| result.get("content"))
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string)
-            });
-        if let Some(before_text) = before.as_deref() {
-            let end = before_text.lines().count();
-            record_acp_file_read_observation(session_id, path, before_text, 0, end, before_text);
-        }
-
-        match self
-            .client_request(
-                "fs/write_text_file",
-                Some(json!({"path": path, "content": content})),
-            )
-            .await
-        {
-            Ok(_) => {
-                record_acp_diff_observation(
-                    session_id,
-                    path,
-                    before.as_deref().unwrap_or_default(),
-                    content,
-                );
-                AcpToolResult {
-                    content: format!("Successfully wrote to {path}"),
-                    is_error: false,
-                }
-            }
-            Err(e) => AcpToolResult {
-                content: format!("Failed to write file: {e}"),
-                is_error: true,
-            },
-        }
+        self.execute_local_tool_async(
+            session_id,
+            "write_file",
+            &json!({"path": path, "content": content}).to_string(),
+        )
+        .await
     }
 
     async fn acp_edit_file(
@@ -2247,83 +2192,21 @@ impl AcpServer {
             Err(result) => return result,
         };
 
-        // Read the file via ACP
-        let file_content = match self
-            .client_request("fs/read_text_file", Some(json!({"path": path})))
-            .await
-        {
-            Ok(result) => result
-                .get("text")
-                .or_else(|| result.get("content"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            Err(e) => {
-                return AcpToolResult {
-                    content: format!("Failed to read file for edit: {e}"),
-                    is_error: true,
-                }
-            }
-        };
-        let file_end = file_content.lines().count();
-        record_acp_file_read_observation(
+        self.execute_local_tool_async(
             session_id,
-            path,
-            &file_content,
-            0,
-            file_end,
-            &file_content,
-        );
-
-        let (new_content, count) = if replace_all {
-            let count = file_content.matches(old_string).count();
-            (file_content.replace(old_string, new_string), count)
-        } else if file_content.contains(old_string) {
-            (file_content.replacen(old_string, new_string, 1), 1)
-        } else {
-            return AcpToolResult {
-                content: format!(
-                    "old_string not found in {path}. Read the file first to see exact content."
-                ),
-                is_error: true,
-            };
-        };
-
-        if count == 0 {
-            return AcpToolResult {
-                content: format!("old_string not found in {path}"),
-                is_error: true,
-            };
-        }
-
-        // Write back via ACP
-        match self
-            .client_request(
-                "fs/write_text_file",
-                Some(json!({"path": path, "content": new_content})),
-            )
-            .await
-        {
-            Ok(_) => {
-                record_acp_diff_observation(session_id, path, &file_content, &new_content);
-                AcpToolResult {
-                    content: format!(
-                        "Successfully edited {} ({} replacement{})",
-                        path,
-                        count,
-                        if count == 1 { "" } else { "s" }
-                    ),
-                    is_error: false,
-                }
-            }
-            Err(e) => AcpToolResult {
-                content: format!("Failed to write edited file: {e}"),
-                is_error: true,
-            },
-        }
+            "edit_file",
+            &json!({
+                "path": path,
+                "old_string": old_string,
+                "new_string": new_string,
+                "replace_all": replace_all
+            })
+            .to_string(),
+        )
+        .await
     }
 
-    // -- Terminal operations via ACP client --
+    // -- Sandboxed terminal operations --
 
     async fn acp_bash(&self, session_id: &str, args: &HashMap<String, Value>) -> AcpToolResult {
         let command = match parse_acp_required_string_arg(args, "command") {
@@ -2335,158 +2218,46 @@ impl AcpServer {
             Ok(value) => value,
             Err(result) => return result,
         };
-        let cwd = std::env::current_dir().unwrap_or_default();
-
-        // Create terminal
-        let terminal_id = match self
-            .client_request(
-                "terminal/create",
-                Some(json!({
-                    "command": command,
-                    "cwd": cwd.to_string_lossy().to_string(),
-                })),
-            )
+        let local_args = json!({
+            "command": command,
+            "run_in_background": run_in_background,
+        });
+        self.execute_local_tool_async(session_id, "bash", &local_args.to_string())
             .await
-        {
-            Ok(result) => result
-                .get("terminalId")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            Err(e) => {
-                return AcpToolResult {
-                    content: format!("Failed to create terminal: {e}"),
-                    is_error: true,
-                }
-            }
+    }
+
+    fn acp_bash_output(&self, session_id: &str, args: &HashMap<String, Value>) -> AcpToolResult {
+        let shell_id = match parse_acp_required_alias_string_arg(
+            args,
+            "shell_id",
+            "terminal_id",
+            "shell_id",
+        ) {
+            Ok(shell_id) => shell_id,
+            Err(result) => return result,
         };
-
-        if run_in_background {
-            record_acp_background_command_start(session_id, &cwd, command);
-            return AcpToolResult {
-                content: format!(
-                    "Background shell started with terminal ID: {terminal_id}\nUse bash_output with this ID to retrieve output."
-                ),
-                is_error: false,
-            };
-        }
-
-        // Wait for completion
-        let exit_result = match self
-            .client_request(
-                "terminal/wait_for_exit",
-                Some(json!({"terminalId": terminal_id})),
-            )
-            .await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                return AcpToolResult {
-                    content: format!("Failed waiting for terminal: {e}"),
-                    is_error: true,
-                }
-            }
-        };
-
-        // Get output
-        let output = self
-            .client_request("terminal/output", Some(json!({"terminalId": terminal_id})))
-            .await
-            .map_or_else(
-                |_| String::new(),
-                |result| {
-                    result
-                        .get("output")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string()
-                },
-            );
-
-        // Release terminal
-        let _ = self
-            .client_request("terminal/release", Some(json!({"terminalId": terminal_id})))
-            .await;
-
-        let exit_code = exit_result
-            .get("exitCode")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(-1);
-
-        let stdout = output.as_str();
-        let stderr = "";
-        crate::tools::record_command_observation_for_session(
+        self.execute_local_tool(
             session_id,
-            &cwd,
-            command,
-            i32::try_from(exit_code).unwrap_or(-1),
-            stdout,
-            stderr,
-        );
-
-        AcpToolResult {
-            content: if output.is_empty() {
-                format!("(exit code {exit_code})")
-            } else {
-                format!("{output}\n(exit code {exit_code})")
-            },
-            is_error: exit_code != 0,
-        }
+            "bash_output",
+            &json!({"shell_id": shell_id}).to_string(),
+        )
     }
 
-    async fn acp_bash_output(&self, args: &HashMap<String, Value>) -> AcpToolResult {
-        let terminal_id = match parse_acp_required_alias_string_arg(
+    fn acp_kill_shell(&self, session_id: &str, args: &HashMap<String, Value>) -> AcpToolResult {
+        let shell_id = match parse_acp_required_alias_string_arg(
             args,
             "shell_id",
             "terminal_id",
             "shell_id",
         ) {
-            Ok(terminal_id) => terminal_id,
+            Ok(shell_id) => shell_id,
             Err(result) => return result,
         };
-
-        match self
-            .client_request("terminal/output", Some(json!({"terminalId": terminal_id})))
-            .await
-        {
-            Ok(result) => {
-                let output = result.get("output").and_then(|v| v.as_str()).unwrap_or("");
-                AcpToolResult {
-                    content: output.to_string(),
-                    is_error: false,
-                }
-            }
-            Err(e) => AcpToolResult {
-                content: format!("Failed to get terminal output: {e}"),
-                is_error: true,
-            },
-        }
-    }
-
-    async fn acp_kill_shell(&self, args: &HashMap<String, Value>) -> AcpToolResult {
-        let terminal_id = match parse_acp_required_alias_string_arg(
-            args,
-            "shell_id",
-            "terminal_id",
-            "shell_id",
-        ) {
-            Ok(terminal_id) => terminal_id,
-            Err(result) => return result,
-        };
-
-        match self
-            .client_request("terminal/kill", Some(json!({"terminalId": terminal_id})))
-            .await
-        {
-            Ok(_) => AcpToolResult {
-                content: format!("Terminal {terminal_id} killed"),
-                is_error: false,
-            },
-            Err(e) => AcpToolResult {
-                content: format!("Failed to kill terminal: {e}"),
-                is_error: true,
-            },
-        }
+        self.execute_local_tool(
+            session_id,
+            "kill_shell",
+            &json!({"shell_id": shell_id}).to_string(),
+        )
     }
 
     async fn acp_list_files(
@@ -2498,19 +2269,8 @@ impl AcpServer {
             Ok(path) => path,
             Err(result) => return result,
         };
-        let command = match acp_list_files_command(path) {
-            Ok(command) => command,
-            Err(content) => {
-                return AcpToolResult {
-                    content,
-                    is_error: true,
-                };
-            }
-        };
-        // Delegate as a terminal command
-        let mut ls_args = HashMap::new();
-        ls_args.insert("command".to_string(), Value::String(command));
-        self.acp_bash(session_id, &ls_args).await
+        self.execute_local_tool_async(session_id, "list_files", &json!({"path": path}).to_string())
+            .await
     }
 
     async fn acp_search(
@@ -2519,156 +2279,62 @@ impl AcpServer {
         tool_args: &HashMap<String, Value>,
         tool_name: &str,
     ) -> AcpToolResult {
-        // SECURITY (#688): user-/model-supplied search arguments must NEVER be
-        // interpolated into a shell command. Build an argv vector and execute
-        // the resolved binary directly via `Command`, bypassing the ACP
-        // `terminal/create` shell entirely. Metacharacters become literal
-        // argv entries; `--` blocks flag injection from the pattern/path.
-        let (program, argv) = match build_search_argv(tool_name, tool_args) {
-            Ok(plan) => plan,
+        let arguments_json = match serde_json::to_string(tool_args) {
+            Ok(arguments) => arguments,
             Err(err) => {
                 return AcpToolResult {
-                    content: err,
+                    content: format!("Failed to serialize {tool_name} arguments: {err}"),
                     is_error: true,
-                };
+                }
             }
         };
-
-        run_search_argv(session_id, &program, &argv).await
+        self.execute_local_tool_async(session_id, tool_name, &arguments_json)
+            .await
     }
 }
 
-/// Output cap for search subprocesses (bytes). Replaces the previous
-/// `| head -N` pipeline, which only worked because the command was being
-/// shell-interpreted.
-const SEARCH_OUTPUT_CAP_BYTES: usize = 256 * 1024;
-const ACP_LEDGER_EXCERPT_MAX_BYTES: usize = 100_000;
+fn execute_local_tool_with_permission(
+    permission_mgr: &PermissionManager,
+    session_id: &str,
+    tool_name: &str,
+    arguments_json: &str,
+) -> AcpToolResult {
+    use crate::tools::{FunctionCall, ToolCall};
+
+    let tc = ToolCall {
+        id: "local".to_string(),
+        call_type: "function".to_string(),
+        function: FunctionCall {
+            name: tool_name.to_string(),
+            arguments: arguments_json.to_string(),
+        },
+    };
+
+    let result = crate::services::tool_executor::ToolExecutor::execute(
+        crate::services::tool_executor::ToolExecutorRequest {
+            tool_call: &tc,
+            memory_db: None,
+            app_config: None,
+            task_mgr: None,
+            permission_mgr: Some(permission_mgr),
+            // `execute_tool_via_acp` performs the headless permission gate
+            // before dispatch, so this worker must not make a second decision.
+            permission_already_checked: true,
+            session_id: Some(session_id),
+            policy_enforcer: None,
+        },
+    );
+    AcpToolResult {
+        content: result.content,
+        is_error: result.is_error,
+    }
+}
+
+#[cfg(test)]
 const ACP_BACKGROUND_COMMAND_PENDING_STDERR: &str =
     "background command started; completion pending via bash_output";
 
-fn record_acp_file_read_observation(
-    session_id: &str,
-    path: &str,
-    full_text: &str,
-    start: usize,
-    end: usize,
-    excerpt: &str,
-) {
-    let mut ledger = match crate::ledger::RealityLedger::open_project_session(session_id) {
-        Ok(ledger) => ledger,
-        Err(err) => {
-            tracing::warn!(
-                session_id,
-                path,
-                error = %err,
-                "failed to open session reality ledger for ACP file read"
-            );
-            return;
-        }
-    };
-    let (start_line, end_line) = acp_read_line_range(full_text, start, end);
-    if let Err(err) = ledger.observe_file_read(
-        path.to_string(),
-        full_text,
-        start_line,
-        end_line,
-        crate::tools::safe_truncate(excerpt, ACP_LEDGER_EXCERPT_MAX_BYTES).to_string(),
-    ) {
-        tracing::warn!(
-            session_id,
-            path,
-            error = %err,
-            "failed to append ACP file read observation to reality ledger"
-        );
-    }
-}
-
-fn acp_read_line_range(full_text: &str, start: usize, end: usize) -> (usize, usize) {
-    let total_lines = if full_text.is_empty() {
-        0
-    } else {
-        full_text.lines().count().max(1)
-    };
-    if total_lines == 0 {
-        return (0, 0);
-    }
-    let bounded_start = start.min(total_lines.saturating_sub(1));
-    let bounded_end = end.clamp(bounded_start + 1, total_lines);
-    (bounded_start + 1, bounded_end)
-}
-
-fn record_acp_diff_observation(session_id: &str, path: &str, before: &str, after: &str) {
-    if before == after {
-        return;
-    }
-    let mut ledger = match crate::ledger::RealityLedger::open_project_session(session_id) {
-        Ok(ledger) => ledger,
-        Err(err) => {
-            tracing::warn!(
-                session_id,
-                path,
-                error = %err,
-                "failed to open session reality ledger for ACP diff"
-            );
-            return;
-        }
-    };
-    let diff_patch = similar::TextDiff::from_lines(before, after)
-        .unified_diff()
-        .header(&format!("a/{path}"), &format!("b/{path}"))
-        .to_string();
-    if let Err(err) = ledger.observe_diff(vec![path.to_string()], diff_patch) {
-        tracing::warn!(
-            session_id,
-            path,
-            error = %err,
-            "failed to append ACP diff observation to reality ledger"
-        );
-    }
-}
-
-fn record_acp_command_argv_observation(
-    session_id: &str,
-    program: &std::path::Path,
-    argv: &[String],
-    exit_code: i32,
-    stdout: &str,
-    stderr: &str,
-) {
-    let mut ledger = match crate::ledger::RealityLedger::open_project_session(session_id) {
-        Ok(ledger) => ledger,
-        Err(err) => {
-            tracing::warn!(
-                session_id,
-                error = %err,
-                "failed to open session reality ledger for ACP command"
-            );
-            return;
-        }
-    };
-    let cwd = std::env::current_dir()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
-    let mut ledger_argv = Vec::with_capacity(argv.len() + 1);
-    ledger_argv.push(program.to_string_lossy().to_string());
-    ledger_argv.extend(argv.iter().cloned());
-    if let Err(err) = ledger.observe_command_run(
-        cwd,
-        ledger_argv,
-        exit_code,
-        crate::tools::safe_truncate(stdout, ACP_LEDGER_EXCERPT_MAX_BYTES).to_string(),
-        crate::tools::safe_truncate(stderr, ACP_LEDGER_EXCERPT_MAX_BYTES).to_string(),
-    ) {
-        tracing::warn!(
-            session_id,
-            program = %program.display(),
-            error = %err,
-            "failed to append ACP command observation to reality ledger"
-        );
-    }
-}
-
+#[cfg(test)]
 fn record_acp_background_command_start(session_id: &str, cwd: &std::path::Path, command: &str) {
     let mut ledger = match crate::ledger::RealityLedger::open_project_session(session_id) {
         Ok(ledger) => ledger,
@@ -2733,6 +2399,7 @@ fn record_acp_tool_result_observation(
     }
 }
 
+#[cfg(test)]
 fn acp_list_files_command(path: &str) -> Result<String, String> {
     let quoted = shlex::try_quote(path).map_err(|err| format!("Invalid list_files path: {err}"))?;
     Ok(format!("ls -la -- {quoted}"))
@@ -2745,6 +2412,7 @@ fn acp_list_files_command(path: &str) -> Result<String, String> {
 /// absolute path so the caller invokes a known binary instead of relying on
 /// `Command::new`'s implicit lookup (which still works, but is harder to
 /// audit and to exercise in tests).
+#[cfg(test)]
 fn resolve_program(name: &str) -> Option<std::path::PathBuf> {
     // Reject obviously path-like or unsafe names — search tools are bare
     // executable names (`rg`, `find`), not paths.
@@ -2780,6 +2448,7 @@ fn resolve_program(name: &str) -> Option<std::path::PathBuf> {
 /// plus argv. No shell, no interpolation. Returns `Err` with a
 /// human-readable reason when the tool name is unknown or the binary cannot
 /// be located on `PATH`.
+#[cfg(test)]
 fn build_search_argv(
     tool_name: &str,
     tool_args: &HashMap<String, Value>,
@@ -2848,6 +2517,7 @@ fn build_search_argv(
     }
 }
 
+#[cfg(test)]
 fn required_acp_search_string_arg(
     tool_args: &HashMap<String, Value>,
     key: &'static str,
@@ -2858,6 +2528,7 @@ fn required_acp_search_string_arg(
         .map_err(|e| e.to_string())
 }
 
+#[cfg(test)]
 fn optional_acp_search_string_arg(
     tool_args: &HashMap<String, Value>,
     key: &'static str,
@@ -2867,6 +2538,7 @@ fn optional_acp_search_string_arg(
         .map(|value| value.unwrap_or_else(|| default.to_string()))
 }
 
+#[cfg(test)]
 fn optional_acp_search_string_arg_opt(
     tool_args: &HashMap<String, Value>,
     key: &'static str,
@@ -2879,6 +2551,7 @@ fn optional_acp_search_string_arg_opt(
     })
 }
 
+#[cfg(test)]
 fn parse_acp_bool_arg_for_search(
     args: &HashMap<String, Value>,
     key: &'static str,
@@ -2888,6 +2561,7 @@ fn parse_acp_bool_arg_for_search(
         .map_err(|e| e.to_string())
 }
 
+#[cfg(test)]
 fn parse_acp_search_context_lines_arg(value: Option<&Value>) -> Result<usize, String> {
     let Some(value) = value else {
         return Ok(0);
@@ -2896,58 +2570,6 @@ fn parse_acp_search_context_lines_arg(value: Option<&Value>) -> Result<usize, St
         return Err("Error: context_lines must be a non-negative integer".to_string());
     };
     Ok(usize::try_from(context).unwrap_or(usize::MAX))
-}
-
-/// Execute the resolved program with the planned argv and return a result
-/// suitable for an ACP tool reply. Output is byte-capped (replacing the
-/// former `| head -N` shell pipeline) and stdout+stderr are merged in the
-/// natural order Tokio gives us.
-async fn run_search_argv(
-    session_id: &str,
-    program: &std::path::Path,
-    argv: &[String],
-) -> AcpToolResult {
-    let output = match tokio::process::Command::new(program)
-        .args(argv)
-        .output()
-        .await
-    {
-        Ok(out) => out,
-        Err(e) => {
-            return AcpToolResult {
-                content: format!("Failed to spawn {}: {e}", program.display()),
-                is_error: true,
-            };
-        }
-    };
-
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let mut combined = stdout.clone();
-    if !stderr.is_empty() {
-        // Surface stderr (rg prints "No files were searched" etc. there)
-        // but only when present, so happy paths stay clean.
-        combined.push_str(&stderr);
-    }
-    if combined.len() > SEARCH_OUTPUT_CAP_BYTES {
-        combined.truncate(SEARCH_OUTPUT_CAP_BYTES);
-        combined.push_str("\n[output truncated]");
-    }
-
-    let exit_code = output.status.code().unwrap_or(-1);
-    record_acp_command_argv_observation(session_id, program, argv, exit_code, &stdout, &stderr);
-    let content = if combined.is_empty() {
-        format!("(exit code {exit_code})")
-    } else {
-        format!("{combined}\n(exit code {exit_code})")
-    };
-    AcpToolResult {
-        content,
-        // `rg` exits non-zero when there are no matches — that's not a tool
-        // error, just an empty result. Treat exit codes 0 and 1 from rg as
-        // success; anything else is a real failure.
-        is_error: !(exit_code == 0 || exit_code == 1),
-    }
 }
 
 // ============================================================================
@@ -3119,8 +2741,13 @@ pub async fn run_acp_server(
         }
     });
 
-    // Spawn stdin reader on a blocking thread — stdin.lock() is not Send
+    let mut server = AcpServer::new(config, model, api_key, claude_code_token, stdout_tx);
+
+    // Spawn stdin reader on a blocking thread — stdin.lock() is not Send.
+    // Cancellation is raised here, before the sequential dispatcher receives
+    // the message, so an in-flight prompt/tool cannot starve session/cancel.
     let (stdin_tx, mut stdin_rx) = mpsc::unbounded_channel::<String>();
+    let reader_cancel = Arc::clone(&server.cancel_flag);
     std::thread::spawn(move || {
         let stdin = io::stdin();
         let reader = stdin.lock();
@@ -3128,6 +2755,19 @@ pub async fn run_acp_server(
             match line_result {
                 Ok(line) => {
                     let trimmed = line.trim().to_string();
+                    if serde_json::from_str::<Value>(&trimmed)
+                        .ok()
+                        .and_then(|value| {
+                            value
+                                .get("method")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                        })
+                        .as_deref()
+                        == Some("session/cancel")
+                    {
+                        reader_cancel.store(true, Ordering::SeqCst);
+                    }
                     if !trimmed.is_empty() && stdin_tx.send(trimmed).is_err() {
                         break;
                     }
@@ -3135,9 +2775,9 @@ pub async fn run_acp_server(
                 Err(_) => break,
             }
         }
+        reader_cancel.store(true, Ordering::SeqCst);
+        crate::tools::cancel_all_sandbox_processes();
     });
-
-    let mut server = AcpServer::new(config, model, api_key, claude_code_token, stdout_tx);
 
     info!("ACP server started on stdio");
 
@@ -3663,23 +3303,9 @@ mod search_security_tests {
 #[cfg(test)]
 mod acp_ledger_helper_tests {
     use super::{
-        acp_read_line_range, record_acp_background_command_start,
-        record_acp_tool_result_observation, AcpToolResult, ACP_BACKGROUND_COMMAND_PENDING_STDERR,
-        ACP_LEDGER_EXCERPT_MAX_BYTES,
+        record_acp_background_command_start, record_acp_tool_result_observation, AcpToolResult,
+        ACP_BACKGROUND_COMMAND_PENDING_STDERR,
     };
-
-    #[test]
-    fn acp_read_line_range_maps_slice_offsets_to_one_based_lines() {
-        assert_eq!(acp_read_line_range("a\nb\nc\n", 0, 3), (1, 3));
-        assert_eq!(acp_read_line_range("a\nb\nc\n", 1, 2), (2, 2));
-    }
-
-    #[test]
-    fn acp_read_line_range_never_returns_inverted_ranges() {
-        assert_eq!(acp_read_line_range("", 0, 0), (0, 0));
-        assert_eq!(acp_read_line_range("a\nb\nc\n", 99, 99), (3, 3));
-        assert_eq!(acp_read_line_range("a\nb\nc\n", 1, 1), (2, 2));
-    }
 
     #[test]
     fn acp_tool_result_observer_records_bounded_result_envelope() {
@@ -3689,7 +3315,7 @@ mod acp_ledger_helper_tests {
         let _ = std::fs::remove_file(&path);
 
         let result = AcpToolResult {
-            content: "x".repeat(ACP_LEDGER_EXCERPT_MAX_BYTES + 128),
+            content: "x".repeat(crate::grounded_loop::TOOL_RESULT_LEDGER_CONTENT_MAX_BYTES + 128),
             is_error: true,
         };
         record_acp_tool_result_observation(session_id, "read_file", "call_acp", &result);
@@ -3978,7 +3604,7 @@ mod session_mode_tests {
     use std::collections::{HashMap, VecDeque};
     use std::sync::atomic::{AtomicBool, AtomicU64};
     use std::sync::Arc;
-    use tokio::sync::{mpsc, Mutex};
+    use tokio::sync::mpsc;
 
     fn test_config() -> AppConfig {
         serde_yaml::from_str(
@@ -4013,12 +3639,10 @@ providers:
             model: "local-model".to_string(),
             api_key: None,
             claude_code_token: None,
-            permission_mgr: PermissionManager::unrestricted(),
+            permission_mgr: Arc::new(PermissionManager::unrestricted()),
             policy_enforcer: Arc::new(crate::services::policy::PolicyEnforcer::new(
                 crate::services::policy::EnterprisePolicy::default(),
             )),
-            next_request_id: AtomicU64::new(1),
-            pending_responses: Arc::new(Mutex::new(HashMap::new())),
             cancel_flag: Arc::new(AtomicBool::new(false)),
             stdout_tx,
             config_options: HashMap::new(),
@@ -4049,25 +3673,6 @@ providers:
             rx.try_recv().is_err(),
             "{context} must fail before emitting an ACP client request"
         );
-    }
-
-    async fn respond_to_next_client_request(
-        server: &AcpServer,
-        rx: &mut mpsc::UnboundedReceiver<String>,
-        result: Value,
-    ) -> Value {
-        let line = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
-            .await
-            .expect("timed out waiting for ACP client request")
-            .expect("expected ACP client request");
-        let request: Value = serde_json::from_str(&line).expect("client request must be JSON");
-        let id = request["id"].as_u64().expect("client request id");
-        let tx = {
-            let mut pending = server.pending_responses.lock().await;
-            pending.remove(&id).expect("pending response channel")
-        };
-        tx.send(Ok(result)).expect("send fake client response");
-        request
     }
 
     #[tokio::test]
@@ -4185,29 +3790,152 @@ providers:
             ("limit".to_string(), json!(1)),
         ]);
 
-        let read = server.acp_read_file("acp-window", &args);
-        let respond = async {
-            let request = respond_to_next_client_request(
-                &server,
-                &mut rx,
-                json!({"text": "first\nsecond\nthird"}),
-            )
-            .await;
-            assert_eq!(request["method"], "fs/read_text_file");
-            assert_eq!(request["params"]["path"], "src/lib.rs");
-        };
-        let (result, ()) = tokio::join!(read, respond);
+        let expected = std::fs::read_to_string("src/lib.rs")
+            .expect("read fixture")
+            .lines()
+            .nth(1)
+            .expect("fixture has a second line")
+            .to_string();
+        let result = server.acp_read_file("acp-window", &args).await;
 
         assert!(!result.is_error, "valid window must succeed: {result:?}");
         assert!(
-            result.content.contains("\tsecond"),
-            "offset=2 limit=1 must show line 2; got {}",
+            result.content.contains(&format!("| {expected}")),
+            "offset=2 limit=1 must show the fixture's line 2; got {}",
             result.content
         );
         assert!(
-            !result.content.contains("\tfirst") && !result.content.contains("\tthird"),
-            "offset/limit window must only show one line; got {}",
+            result
+                .content
+                .lines()
+                .filter(|line| line.contains('|'))
+                .count()
+                == 1,
+            "offset/limit window must return exactly one numbered content line; got {}",
             result.content
+        );
+        assert_no_client_request(&mut rx, "local ACP read");
+    }
+
+    #[tokio::test]
+    async fn acp_filesystem_operations_cannot_expand_local_capabilities() {
+        let (server, mut rx, _tmp) = test_server();
+        let outside = tempfile::tempdir().expect("outside capability fixture");
+        let sentinel = outside.path().join("sentinel.txt");
+        std::fs::write(&sentinel, "outside-secret").expect("outside sentinel");
+
+        let read = server
+            .acp_read_file(
+                "acp-capability-jail",
+                &HashMap::from([(
+                    "path".to_string(),
+                    Value::String(sentinel.to_string_lossy().into_owned()),
+                )]),
+            )
+            .await;
+        assert!(read.is_error);
+        assert!(!read.content.contains("outside-secret"));
+
+        let write = server
+            .acp_write_file(
+                "acp-capability-jail",
+                &HashMap::from([
+                    (
+                        "path".to_string(),
+                        Value::String(sentinel.to_string_lossy().into_owned()),
+                    ),
+                    ("content".to_string(), Value::String("changed".to_string())),
+                ]),
+            )
+            .await;
+        assert!(write.is_error);
+        assert_eq!(
+            std::fs::read_to_string(&sentinel).expect("outside sentinel"),
+            "outside-secret"
+        );
+
+        let traversal = server
+            .acp_read_file(
+                "acp-capability-jail",
+                &HashMap::from([(
+                    "path".to_string(),
+                    Value::String("../outside.txt".to_string()),
+                )]),
+            )
+            .await;
+        assert!(traversal.is_error);
+
+        let search = server
+            .acp_search(
+                "acp-capability-jail",
+                &HashMap::from([
+                    ("pattern".to_string(), Value::String("outside".to_string())),
+                    (
+                        "path".to_string(),
+                        Value::String(outside.path().to_string_lossy().into_owned()),
+                    ),
+                ]),
+                "grep",
+            )
+            .await;
+        assert!(search.is_error);
+        assert!(!search.content.contains("outside-secret"));
+
+        #[cfg(unix)]
+        {
+            let inside = tempfile::tempdir_in(".").expect("project-local fixture");
+            let link = inside.path().join("outside-link");
+            std::os::unix::fs::symlink(&sentinel, &link).expect("outside symlink");
+            let linked = server
+                .acp_read_file(
+                    "acp-capability-jail",
+                    &HashMap::from([(
+                        "path".to_string(),
+                        Value::String(link.to_string_lossy().into_owned()),
+                    )]),
+                )
+                .await;
+            assert!(linked.is_error);
+            assert!(!linked.content.contains("outside-secret"));
+        }
+
+        assert_no_client_request(&mut rx, "locally confined ACP filesystem tools");
+    }
+
+    #[test]
+    fn ide_unsaved_buffers_require_session_scoped_file_capability() {
+        let (mut server, _rx, _tmp) = test_server();
+        server.handle_ide_file_opened(&json!({
+            "sessionId": "ide-capability-session",
+            "filePath": "src/lib.rs",
+            "text": "unsaved editor contents"
+        }));
+        assert_eq!(
+            server.ide_state.active_file.as_deref(),
+            Some("src/lib.rs"),
+            "project-local unsaved buffer should be accepted"
+        );
+
+        let outside = tempfile::NamedTempFile::new().expect("outside IDE fixture");
+        server.handle_ide_file_opened(&json!({
+            "sessionId": "ide-capability-session",
+            "filePath": outside.path(),
+            "text": "outside unsaved secret"
+        }));
+        assert_eq!(
+            server.ide_state.active_file.as_deref(),
+            Some("src/lib.rs"),
+            "outside buffer notification must be dropped"
+        );
+
+        server.handle_ide_file_opened(&json!({
+            "filePath": "src/main.rs",
+            "text": "unscoped"
+        }));
+        assert_eq!(
+            server.ide_state.active_file.as_deref(),
+            Some("src/lib.rs"),
+            "notification without a session id must be dropped"
         );
     }
 
@@ -4319,11 +4047,72 @@ providers:
     }
 
     #[tokio::test]
-    async fn acp_bash_output_rejects_wrong_type_shell_id_before_client_request() {
+    async fn acp_bash_executes_locally_without_terminal_client_delegation() {
+        let (server, mut rx, _tmp) = test_server();
+        let args = HashMap::from([
+            ("command".to_string(), json!("echo acp_sandbox_probe")),
+            ("run_in_background".to_string(), json!(false)),
+        ]);
+
+        let result = server.acp_bash("acp-local-bash", &args).await;
+
+        assert!(!result.is_error, "local ACP bash failed: {result:?}");
+        assert!(result.content.contains("acp_sandbox_probe"));
+        assert_no_client_request(&mut rx, "ACP bash sandbox routing");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn acp_foreground_bash_cancellation_terminates_descendants_promptly() {
+        let (server, _rx, _tmp) = test_server();
+        let fixture = tempfile::tempdir_in(".").expect("project-local cancellation fixture");
+        let escaped_marker = fixture.path().join("descendant-survived");
+        let marker = shlex::try_quote(
+            escaped_marker
+                .to_str()
+                .expect("cancellation marker must be UTF-8"),
+        )
+        .expect("quote cancellation marker");
+        let args = HashMap::from([
+            (
+                "command".to_string(),
+                json!(format!("(sleep 1; echo escaped > {marker}) & sleep 30")),
+            ),
+            ("run_in_background".to_string(), json!(false)),
+        ]);
+        let cancel = Arc::clone(&server.cancel_flag);
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        let started = std::time::Instant::now();
+        let result = server.acp_bash("acp-cancel-tree", &args).await;
+        assert!(
+            result.is_error,
+            "cancelled tool must be reported as an error"
+        );
+        assert!(
+            result.content.contains("cancelled"),
+            "unexpected cancellation result: {result:?}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(8),
+            "ACP cancellation did not return promptly"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(1_200)).await;
+        assert!(
+            !escaped_marker.exists(),
+            "a daemonized sandbox descendant survived ACP cancellation: {result:?}"
+        );
+    }
+
+    #[test]
+    fn acp_bash_output_rejects_wrong_type_shell_id_before_client_request() {
         let (server, mut rx, _tmp) = test_server();
         let args = HashMap::from([("shell_id".to_string(), json!(42))]);
 
-        let result = server.acp_bash_output(&args).await;
+        let result = server.acp_bash_output("acp-bad-output", &args);
 
         assert!(result.is_error, "bad shell_id must error: {result:?}");
         assert!(
@@ -4336,12 +4125,12 @@ providers:
         assert_no_client_request(&mut rx, "bad bash_output shell_id");
     }
 
-    #[tokio::test]
-    async fn acp_kill_shell_rejects_wrong_type_terminal_id_before_client_request() {
+    #[test]
+    fn acp_kill_shell_rejects_wrong_type_terminal_id_before_client_request() {
         let (server, mut rx, _tmp) = test_server();
         let args = HashMap::from([("terminal_id".to_string(), json!({"id": "term"}))]);
 
-        let result = server.acp_kill_shell(&args).await;
+        let result = server.acp_kill_shell("acp-bad-kill", &args);
 
         assert!(result.is_error, "bad terminal_id must error: {result:?}");
         assert!(
@@ -4911,7 +4700,7 @@ mod pre_tool_gate_tests {
     /// when the wiring regresses.
     #[tokio::test]
     async fn hook_denial_blocks_tool_dispatch() {
-        let tmp = tempfile::tempdir().expect("tempdir");
+        let tmp = tempfile::tempdir_in(".").expect("project-local tempdir");
         let script = write_deny_script(tmp.path(), "blocked-by-policy");
 
         let mut cfg = HooksConfig::default();
@@ -4951,7 +4740,7 @@ mod pre_tool_gate_tests {
     /// This guards against an over-eager fix that just blocks everything.
     #[tokio::test]
     async fn allowed_tool_passes_through_gate() {
-        let tmp = tempfile::tempdir().expect("tempdir");
+        let tmp = tempfile::tempdir_in(".").expect("project-local tempdir");
         let script = write_deny_script(tmp.path(), "denied");
 
         let mut cfg = HooksConfig::default();
@@ -5012,7 +4801,7 @@ mod pre_tool_gate_tests {
     /// is wired correctly through the ACP code path.
     #[tokio::test]
     async fn matcher_match_triggers_deny() {
-        let tmp = tempfile::tempdir().expect("tempdir");
+        let tmp = tempfile::tempdir_in(".").expect("project-local tempdir");
         let script = write_deny_script(tmp.path(), "bash-not-allowed");
 
         let mut cfg = HooksConfig::default();

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -2478,6 +2478,8 @@ fn build_search_argv(
             let context_lines = parse_acp_search_context_lines_arg(tool_args.get("context_lines"))?;
             let case_insensitive =
                 parse_acp_bool_arg_for_search(tool_args, "case_insensitive", false)?;
+            let file_type = optional_acp_search_string_arg_opt(tool_args, "type")?;
+            let glob = optional_acp_search_string_arg_opt(tool_args, "glob")?;
             let program =
                 resolve_program("rg").ok_or_else(|| "Could not locate `rg` on PATH".to_string())?;
 
@@ -2489,7 +2491,7 @@ fn build_search_argv(
                 argv.push("--context".to_string());
                 argv.push(context_lines.to_string());
             }
-            if let Some(ft) = optional_acp_search_string_arg_opt(tool_args, "type")? {
+            if let Some(ft) = file_type {
                 // The type name itself is an argv entry, but disallow values
                 // that look like flags to keep the contract obvious.
                 if ft.starts_with('-') {
@@ -2498,7 +2500,7 @@ fn build_search_argv(
                 argv.push("--type".to_string());
                 argv.push(ft);
             }
-            if let Some(g) = optional_acp_search_string_arg_opt(tool_args, "glob")? {
+            if let Some(g) = glob {
                 if g.starts_with('-') {
                     return Err(format!("Invalid `glob` value (looks like a flag): {g}"));
                 }

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -153,6 +153,29 @@ pub async fn cmd_doctor() -> anyhow::Result<()> {
 
     let mut has_failures = false;
 
+    let sandbox = openclaudia::tools::sandbox_diagnostics();
+    println!(
+        "Agent sandbox... {}",
+        if sandbox.healthy { "OK" } else { "FAILED" }
+    );
+    println!("  Backend: {}", sandbox.backend);
+    println!("  Detail: {}", sandbox.detail);
+    println!("  Network: {}", sandbox.network);
+    println!("  Syscall policy: {}", sandbox.syscall_filter);
+    println!("  Resource limits: {}", sandbox.resource_limits);
+    println!(
+        "  Capability roots: {} read-only, {} read-write",
+        sandbox.read_only_root_count, sandbox.read_write_root_count
+    );
+    println!(
+        "  Explicit environment grants: {} variable name(s), values redacted",
+        sandbox.environment_grant_count
+    );
+    if sandbox.explicit_host_opt_out {
+        println!("  WARNING: host operator explicitly disabled process isolation");
+    }
+    has_failures |= !sandbox.healthy;
+
     // Check configuration
     print!("Configuration... ");
     let loaded_config = if config::config_file_exists() {
@@ -348,11 +371,23 @@ pub async fn cmd_doctor() -> anyhow::Result<()> {
         if !all_mcp.is_empty() {
             println!("\n  MCP Servers from plugins:");
             for (plugin, server) in all_mcp {
+                let effective_permissions = if server.transport == "stdio" {
+                    format!(
+                        "trust=required, profile=mcp-stdio, network=denied, env-grants={}",
+                        server.env.len()
+                    )
+                } else {
+                    format!(
+                        "trust=required, brokered transport, header-grants={}",
+                        server.headers.len()
+                    )
+                };
                 println!(
-                    "    - {} from {} ({})",
+                    "    - {} from {} ({}; {})",
                     server.name,
                     plugin.name(),
-                    server.transport
+                    server.transport,
+                    effective_permissions
                 );
             }
         }

--- a/src/config/hooks.rs
+++ b/src/config/hooks.rs
@@ -5,36 +5,37 @@ use std::collections::HashSet;
 
 /// Sandbox isolation level applied when spawning a hook command.
 ///
-/// Defaults to [`SandboxMode::EnvScrub`] when a policy is present and the
-/// field is omitted. The weakest mode still scrubs all credentials from the
-/// child environment.
+/// Defaults to [`SandboxMode::FullSandbox`] when a policy is present and the
+/// field is omitted. Weaker modes require a separate host-startup trust
+/// decision; repository configuration alone cannot opt out of isolation.
 #[derive(Debug, Deserialize, Clone, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxMode {
     /// No additional isolation beyond the defaults provided by the OS.
     /// Credentials are still scrubbed (same as `EnvScrub`).
     None,
-    /// Remove every credential-classified env var before spawning (default).
-    #[default]
+    /// Remove every credential-classified env var before spawning.
     EnvScrub,
-    /// Placeholder for future OS-level sandbox (e.g. bubblewrap/nsjail).
-    /// Currently behaves identically to `EnvScrub`; reserved for crosslink #254 Phase 2.
+    /// Run the hook inside the OS subprocess sandbox. Project and hook scripts
+    /// remain readable, while VCS/harness control state is read-only, host
+    /// files and networking are unavailable, and project output is writable.
+    #[default]
     FullSandbox,
 }
 
 /// Per-`HooksConfig` security policy for command hook execution.
 ///
-/// When `None` (the field is absent from the config), hooks run in
-/// **backwards-compatible allow-all mode** — every command is permitted and
-/// `EnvScrub` is applied automatically. A deprecation warning is emitted once
-/// per process so operators know to add an explicit policy.
+/// When `None` (the field is absent from the config), every command name is
+/// permitted but command hooks still run in the full OS sandbox. This keeps
+/// compatibility with existing hook command lists without trusting repository
+/// code with host process access.
 ///
 /// Example config YAML:
 /// ```yaml
 /// hooks:
 ///   policy:
 ///     allowed_commands: ["python", "node", "jq"]
-///     sandbox: env_scrub
+///     sandbox: full_sandbox
 /// ```
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct HookPolicy {
@@ -47,7 +48,7 @@ pub struct HookPolicy {
     #[serde(default)]
     pub allowed_commands: Option<HashSet<String>>,
 
-    /// Isolation mode applied during spawn. Defaults to [`SandboxMode::EnvScrub`].
+    /// Isolation mode applied during spawn. Defaults to [`SandboxMode::FullSandbox`].
     #[serde(default)]
     pub sandbox: SandboxMode,
 }
@@ -56,7 +57,7 @@ pub struct HookPolicy {
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct HooksConfig {
     /// Security policy applied to all command hooks in this config.
-    /// Absent → backwards-compatible allow-all mode (deprecation warning logged once).
+    /// Absent → allow every executable name inside the full OS sandbox.
     #[serde(default)]
     pub policy: Option<HookPolicy>,
     #[serde(default)]
@@ -257,7 +258,7 @@ mod tests {
     fn test_hook_policy_default() {
         let policy = HookPolicy::default();
         assert!(policy.allowed_commands.is_none());
-        assert_eq!(policy.sandbox, SandboxMode::EnvScrub);
+        assert_eq!(policy.sandbox, SandboxMode::FullSandbox);
     }
 
     #[test]
@@ -280,6 +281,7 @@ mod tests {
         let policy = config.policy.unwrap();
         let allowed = policy.allowed_commands.unwrap();
         assert!(allowed.contains("jq"));
+        assert_eq!(policy.sandbox, SandboxMode::FullSandbox);
     }
 
     #[test]

--- a/src/guardrails.rs
+++ b/src/guardrails.rs
@@ -910,79 +910,64 @@ async fn run_shell_command_async(
     cwd_owned: std::path::PathBuf,
     timeout_seconds: u64,
 ) -> ShellResult {
-    let mut cmd = tokio::process::Command::new(&program_owned);
-    cmd.args(&args_owned)
-        .current_dir(&cwd_owned)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        // crosslink #395: when the wall-clock timer fires and the
-        // outer `tokio::time::timeout` returns Err, dropping the
-        // wait_with_output future drops the underlying Child. With
-        // `kill_on_drop(true)`, that drop reliably SIGKILLs the
-        // child instead of leaking it for `timeout_seconds == 30`
-        // worth of sleep. Critical for the `sleep 30` regression
-        // test and for keeping CI runners from accumulating
-        // orphaned processes.
-        .kill_on_drop(true);
-
-    let child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            warn!(
-                program = %program_owned,
-                error = %e,
-                "Quality gate: program not found on PATH"
-            );
-            return ShellResult::ShellMissing {
-                tried: vec![program_owned],
-            };
-        }
-        Err(e) => {
-            error!(program = %program_owned, error = %e, "Quality gate: spawn failed");
+    // Quality gates execute project-controlled build files, compiler plugins,
+    // and test binaries. Running argv directly prevents shell injection but
+    // does not prevent those programs from accessing the host, so use the
+    // same OS boundary as the model-facing Bash tool.
+    let Ok(resolved_program) = which::which(&program_owned) else {
+        return ShellResult::ShellMissing {
+            tried: vec![program_owned],
+        };
+    };
+    let sandbox_args: Vec<std::ffi::OsString> =
+        args_owned.iter().map(std::ffi::OsString::from).collect();
+    let sandboxed = match crate::tools::sandboxed_process_command(
+        crate::tools::SandboxProfile::QualityGate,
+        resolved_program.as_os_str(),
+        &sandbox_args,
+        &cwd_owned,
+    ) {
+        Ok(command) => command,
+        Err(error) => {
+            error!(program = %program_owned, %error, "Quality gate: sandbox setup failed");
             return ShellResult::ExitFailed {
                 code: -1,
                 stdout: String::new(),
-                stderr: format!("Failed to execute: {e}"),
+                stderr: error,
             };
         }
     };
-
-    // `wait_with_output()` consumes the child; if we time out we
-    // have to kill+reap separately using the pre-take Child handle.
-    // Take stdout/stderr handles first so we can drain them in
-    // parallel with the wait inside `wait_with_output`.
-    let wait_fut = child.wait_with_output();
-
-    let result = if timeout_seconds == 0 {
-        match wait_fut.await {
-            Ok(output) => Some(output),
-            Err(e) => {
-                error!(error = %e, "Quality gate: wait_with_output failed");
-                None
-            }
-        }
+    let effective_timeout = Duration::from_secs(if timeout_seconds == 0 {
+        300
     } else {
-        match tokio::time::timeout(Duration::from_secs(timeout_seconds), wait_fut).await {
-            Ok(Ok(output)) => Some(output),
-            Ok(Err(e)) => {
-                error!(error = %e, "Quality gate: wait_with_output failed");
-                None
-            }
-            Err(_) => {
-                // Wall-clock timer fired. Dropping `wait_fut`
-                // drops the Child, which (because we set
-                // `kill_on_drop(true)` above) SIGKILLs the
-                // process before this function returns. The
-                // tokio reaper then collects the zombie
-                // asynchronously.
-                warn!(
-                    program = %program_owned,
-                    timeout_seconds = timeout_seconds,
-                    "Quality gate: command timed out, killing child"
-                );
-                return ShellResult::Timeout;
-            }
+        timeout_seconds
+    });
+    let program_for_worker = program_owned.clone();
+    let result = match tokio::task::spawn_blocking(move || {
+        crate::tools::run_prepared_sandboxed_with_timeout(
+            sandboxed,
+            &program_for_worker,
+            effective_timeout,
+        )
+    })
+    .await
+    {
+        Ok(Ok(output)) => Some(output),
+        Ok(Err(crate::tools::CommandError::TimedOut { .. })) => {
+            warn!(
+                program = %program_owned,
+                timeout_seconds = effective_timeout.as_secs(),
+                "Quality gate: command timed out; sandbox process tree terminated"
+            );
+            return ShellResult::Timeout;
+        }
+        Ok(Err(error)) => {
+            error!(%error, "Quality gate: sandboxed command failed");
+            None
+        }
+        Err(error) => {
+            error!(%error, "Quality gate: blocking worker failed");
+            None
         }
     };
 
@@ -2228,6 +2213,21 @@ mod tests {
             }
             other => panic!("expected Success, got {other:?}"),
         }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn quality_gate_project_code_cannot_write_host_temp_files() {
+        let host_dir = tempfile::TempDir::new().expect("quality-gate host tempdir");
+        let host_file = host_dir.path().join("escape.txt");
+        let command = format!("sh -c \"printf escaped > {}\"", host_file.to_string_lossy());
+
+        let _ = run_shell_command_sync(&command, 5);
+
+        assert!(
+            !host_file.exists(),
+            "project-controlled quality gate escaped its OS sandbox"
+        );
     }
 
     /// Shell-metacharacter survival check: the pre-#395 code used

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -21,7 +21,7 @@ pub use claude_compat::{
 };
 pub use merge::merge_hooks_config;
 
-use crate::config::{Hook, HookEntry, HookMatcherTarget, HookPolicy, HooksConfig};
+use crate::config::{Hook, HookEntry, HookMatcherTarget, HookPolicy, HooksConfig, SandboxMode};
 use crate::tools::is_sensitive_env;
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
@@ -30,10 +30,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use thiserror::Error;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
@@ -41,6 +41,25 @@ use tracing::{debug, error, info, warn};
 /// Emitted once per process the first time a hook runs without an explicit
 /// `HookPolicy`. Prevents repeated log noise while still surfacing the gap.
 static ALLOW_ALL_DEPRECATION_WARNED: AtomicBool = AtomicBool::new(false);
+const TRUST_UNSANDBOXED_HOOKS_ENV: &str = "OPENCLAUDIA_TRUST_UNSANDBOXED_HOOKS";
+static TRUST_UNSANDBOXED_HOOKS: LazyLock<Result<bool, String>> = LazyLock::new(|| {
+    std::env::var_os(TRUST_UNSANDBOXED_HOOKS_ENV).map_or(Ok(false), |value| {
+        let value = value.to_str().ok_or_else(|| {
+            format!(
+                "{TRUST_UNSANDBOXED_HOOKS_ENV} contains non-Unicode data; refusing host hook execution"
+            )
+        })?;
+        match value.trim().to_ascii_lowercase().as_str() {
+            "" | "0" | "false" | "off" | "no" => Ok(false),
+            "1" | "true" | "on" | "yes" => Ok(true),
+            _ => Err(format!(
+                "Invalid {TRUST_UNSANDBOXED_HOOKS_ENV} value '{value}'; use 'false' (default) or 'true'"
+            )),
+        }
+    })
+});
+const MAX_HOOK_OUTPUT_BYTES_PER_STREAM: usize = 1024 * 1024;
+const HOOK_OUTPUT_TRUNCATED_MARKER: &[u8] = b"\n[hook output truncated at 1 MiB]\n";
 
 /// All hook event types supported by `OpenClaudia`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -235,8 +254,8 @@ impl HookInput {
     pub fn new(event: HookEvent) -> Self {
         Self {
             event,
-            cwd: std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
+            cwd: crate::tools::security::current_context()
+                .map(|context| context.working_directory().to_string_lossy().to_string())
                 .unwrap_or_default(),
             session_id: None,
             tool_name: None,
@@ -875,10 +894,10 @@ impl HookEngine {
             None => {
                 if !ALLOW_ALL_DEPRECATION_WARNED.swap(true, Ordering::Relaxed) {
                     warn!(
-                        "HooksConfig has no `policy` field — running in allow-all \
-                         backwards-compatible mode. Add `policy: {{}}` to silence \
-                         this warning, or `policy: {{allowed_commands: [...]}}` to \
-                         restrict which binaries hooks may execute."
+                        "HooksConfig has no `policy` field — allowing every hook \
+                         executable name inside the full OS sandbox. Add \
+                         `policy: {{allowed_commands: [...]}}` to restrict which \
+                         binaries hooks may execute."
                     );
                 }
             }
@@ -929,6 +948,12 @@ impl HookEngine {
     }
 
     async fn terminate_child_after_stdin_failure(child: &mut Child) {
+        if let Some(pid) = child.id() {
+            let _ = tokio::task::spawn_blocking(move || {
+                crate::tools::terminate_process_tree(pid);
+            })
+            .await;
+        }
         if let Err(e) = child.start_kill() {
             debug!(error = %e, "Failed to kill hook process after stdin failure");
         }
@@ -937,15 +962,91 @@ impl HookEngine {
         }
     }
 
+    async fn read_bounded_hook_stream<R>(mut stream: R) -> Result<Vec<u8>, std::io::Error>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let mut retained = Vec::new();
+        let mut chunk = [0u8; 8192];
+        let mut truncated = false;
+        loop {
+            let count = stream.read(&mut chunk).await?;
+            if count == 0 {
+                break;
+            }
+            let remaining = MAX_HOOK_OUTPUT_BYTES_PER_STREAM.saturating_sub(retained.len());
+            let keep = remaining.min(count);
+            retained.extend_from_slice(&chunk[..keep]);
+            truncated |= keep < count;
+        }
+        if truncated {
+            retained.extend_from_slice(HOOK_OUTPUT_TRUNCATED_MARKER);
+        }
+        Ok(retained)
+    }
+
     async fn wait_for_hook_output(
-        child: Child,
+        mut child: Child,
         timeout_secs: u64,
     ) -> Result<std::process::Output, HookError> {
-        match timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await {
-            Ok(Ok(output)) => Ok(output),
-            Ok(Err(e)) => Err(HookError::CommandFailed(e.to_string())),
-            Err(_) => Err(HookError::Timeout(timeout_secs)),
-        }
+        let pid = child.id();
+        let stdout = child.stdout.take().ok_or_else(|| {
+            HookError::CommandFailed("hook stdout unavailable after spawn".to_string())
+        })?;
+        let stderr = child.stderr.take().ok_or_else(|| {
+            HookError::CommandFailed("hook stderr unavailable after spawn".to_string())
+        })?;
+        let stdout_reader = tokio::spawn(Self::read_bounded_hook_stream(stdout));
+        let stderr_reader = tokio::spawn(Self::read_bounded_hook_stream(stderr));
+        let status = match timeout(Duration::from_secs(timeout_secs), child.wait()).await {
+            Ok(Ok(status)) => status,
+            Ok(Err(error)) => {
+                if let Some(pid) = pid {
+                    let _ = tokio::task::spawn_blocking(move || {
+                        crate::tools::terminate_process_tree(pid);
+                    })
+                    .await;
+                }
+                return Err(HookError::CommandFailed(error.to_string()));
+            }
+            Err(_) => {
+                if let Some(pid) = pid {
+                    let _ = tokio::task::spawn_blocking(move || {
+                        crate::tools::terminate_process_tree(pid);
+                    })
+                    .await;
+                }
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                let _ = stdout_reader.await;
+                let _ = stderr_reader.await;
+                return Err(HookError::Timeout(timeout_secs));
+            }
+        };
+        let stdout = stdout_reader
+            .await
+            .map_err(|error| HookError::CommandFailed(error.to_string()))?
+            .map_err(|error| HookError::CommandFailed(error.to_string()))?;
+        let stderr = stderr_reader
+            .await
+            .map_err(|error| HookError::CommandFailed(error.to_string()))?
+            .map_err(|error| HookError::CommandFailed(error.to_string()))?;
+        Ok(std::process::Output {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+
+    #[cfg(unix)]
+    fn isolate_hook_process_group(command: &mut Command) {
+        use std::os::unix::process::CommandExt as _;
+        command.as_std_mut().process_group(0);
+    }
+
+    #[cfg(not(unix))]
+    fn isolate_hook_process_group(_command: &mut Command) {
+        // The enforced Windows backend uses a Job object when available.
     }
 
     /// Execute a command hook.
@@ -967,8 +1068,9 @@ impl HookEngine {
         debug!(command = %command, shell = use_shell, "Running command hook");
 
         // Resolve cwd eagerly — missing cwd is a hard error, not a silent "".
-        let project_dir = std::env::current_dir()
-            .map_err(|e| HookError::CommandFailed(format!("current_dir() failed: {e}")))?;
+        let security =
+            crate::tools::security::current_context().map_err(HookError::CommandFailed)?;
+        let project_dir = security.working_directory().to_path_buf();
 
         let mut child_cmd = if use_shell {
             warn!(
@@ -985,13 +1087,46 @@ impl HookEngine {
         };
 
         Self::apply_hook_env(&mut child_cmd, &project_dir);
+        let sandbox_mode = policy.map_or(SandboxMode::FullSandbox, |hook_policy| {
+            hook_policy.sandbox.clone()
+        });
+        if sandbox_mode == SandboxMode::FullSandbox {
+            let sandboxed = crate::tools::sandboxed_hook_command(child_cmd.as_std(), &project_dir)
+                .map_err(|error| {
+                    HookError::CommandFailed(format!("failed to create full hook sandbox: {error}"))
+                })?;
+            child_cmd = Command::from(sandboxed);
+        } else {
+            let trusted = TRUST_UNSANDBOXED_HOOKS
+                .as_ref()
+                .map_err(Clone::clone)
+                .map_err(HookError::CommandFailed)?;
+            if !trusted {
+                return Err(HookError::CommandFailed(format!(
+                    "hook sandbox mode '{sandbox_mode:?}' requests host execution, which is blocked. \
+                     A host operator must explicitly start OpenClaudia with \
+                     {TRUST_UNSANDBOXED_HOOKS_ENV}=true to trust unsandboxed hooks"
+                )));
+            }
+            warn!(
+                mode = ?sandbox_mode,
+                env = TRUST_UNSANDBOXED_HOOKS_ENV,
+                "Hook OS sandbox explicitly disabled by the host operator"
+            );
+        }
 
+        Self::isolate_hook_process_group(&mut child_cmd);
         let mut child = child_cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| HookError::CommandFailed(e.to_string()))?;
+        let _process_registration = (sandbox_mode == SandboxMode::FullSandbox).then(|| {
+            child
+                .id()
+                .map(crate::tools::command::ActiveSandboxProcess::register)
+        });
 
         let Some(mut stdin) = child.stdin.take() else {
             Self::terminate_child_after_stdin_failure(&mut child).await;
@@ -1002,15 +1137,7 @@ impl HookEngine {
         let stdin_result = Self::write_hook_stdin(&mut stdin, input_json).await;
         drop(stdin);
         if let Err(e) = stdin_result {
-            let output = Self::wait_for_hook_output(child, timeout_secs).await?;
-            if output.status.success() {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                if !stderr.is_empty() {
-                    debug!(stderr = %stderr, "Hook stderr");
-                }
-                return Ok((Self::parse_hook_output(&stdout), 0));
-            }
+            Self::terminate_child_after_stdin_failure(&mut child).await;
             return Err(e);
         }
 
@@ -1021,6 +1148,19 @@ impl HookEngine {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 if !stderr.is_empty() {
                     debug!(stderr = %stderr, "Hook stderr");
+                }
+                if exit_code != 0 && exit_code != 2 {
+                    const MAX_HOOK_ERROR_BYTES: usize = 4096;
+                    let diagnostic =
+                        crate::tools::safe_truncate(stderr.trim(), MAX_HOOK_ERROR_BYTES);
+                    let suffix = if diagnostic.is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {diagnostic}")
+                    };
+                    return Err(HookError::CommandFailed(format!(
+                        "hook process exited with status {exit_code}{suffix}"
+                    )));
                 }
                 Ok((Self::parse_hook_output(&stdout), exit_code))
             }
@@ -1903,7 +2043,7 @@ mod tests {
         use std::collections::HashSet;
         let policy = HookPolicy {
             allowed_commands: Some(HashSet::from(["true".to_string()])),
-            sandbox: SandboxMode::EnvScrub,
+            sandbox: SandboxMode::FullSandbox,
         };
         let engine = HookEngine::new(make_command_config("true", false, Some(policy)));
         let input = HookInput::new(HookEvent::PostToolUse).with_tool("bash", serde_json::json!({}));
@@ -1920,7 +2060,7 @@ mod tests {
         use std::collections::HashSet;
         let policy = HookPolicy {
             allowed_commands: Some(HashSet::from(["python3".to_string()])),
-            sandbox: SandboxMode::EnvScrub,
+            sandbox: SandboxMode::FullSandbox,
         };
         // Attempt to run `true` which is NOT in the allowlist.
         let engine = HookEngine::new(make_command_config("true", false, Some(policy)));
@@ -1952,7 +2092,7 @@ mod tests {
         // The string "; rm -rf /tmp/x" is passed as a *literal argument* to echo.
         let policy = HookPolicy {
             allowed_commands: Some(HashSet::from(["echo".to_string()])),
-            sandbox: SandboxMode::EnvScrub,
+            sandbox: SandboxMode::FullSandbox,
         };
         let engine = HookEngine::new(make_command_config(
             "echo '; rm -rf /tmp/x'",
@@ -2024,7 +2164,7 @@ mod tests {
                 "printenv".to_string(),
                 "sh".to_string(),
             ])),
-            sandbox: SandboxMode::EnvScrub,
+            sandbox: SandboxMode::FullSandbox,
         };
         let engine = HookEngine::new(make_command_config(
             "printenv ANTHROPIC_API_KEY",
@@ -2353,7 +2493,7 @@ mod tests {
         // HookError::Denied on every command-hook invocation.
         let policy = HookPolicy {
             allowed_commands: Some(HashSet::new()),
-            sandbox: SandboxMode::EnvScrub,
+            sandbox: SandboxMode::FullSandbox,
         };
         let config = HooksConfig {
             policy: Some(policy),

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,7 @@ enum Commands {
 // and keeps all futures on one thread, which is required by the `onig`-backed
 // StreamingMarkdownRenderer (holds `*mut` raw pointers that are not Send).
 #[tokio::main(flavor = "current_thread")]
+#[allow(clippy::too_many_lines)]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -259,6 +260,15 @@ async fn main() -> anyhow::Result<()> {
     // logs each and continues.
     let _ =
         openclaudia::migrations::run_all(&openclaudia::migrations::MigrationContext::from_env());
+
+    let agent_capable_surface = cli.print.is_some()
+        || matches!(
+            cli.command.as_ref(),
+            None | Some(Commands::Acp { .. } | Commands::Start { .. } | Commands::Loop { .. })
+        );
+    if agent_capable_surface {
+        openclaudia::tools::sandbox_preflight().map_err(anyhow::Error::msg)?;
+    }
 
     if let Some(prompt) = cli.print.clone() {
         if cli.command.is_some() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,6 +11,8 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
@@ -273,6 +275,7 @@ pub trait McpTransport: Send + Sync {
 /// Stdio transport - communicates with MCP server via stdin/stdout
 pub struct StdioTransport {
     child: Arc<Mutex<Child>>,
+    _process_registration: crate::tools::command::ActiveSandboxProcess,
     reader: Mutex<BufReader<tokio::process::ChildStdout>>,
     request_id: AtomicU64,
     /// Serialises the (`write_request` → `read_response`) pair so
@@ -355,26 +358,58 @@ impl StdioTransport {
         args: &[&str],
         env: &HashMap<String, String>,
     ) -> Result<Self, McpError> {
+        let resolved_command = resolve_trusted_mcp_executable(command)?;
+        let sensitive_grants = mcp_sensitive_environment_grants()?;
+        for key in env.keys() {
+            if is_host_loader_environment(key) {
+                return Err(McpError::Transport(format!(
+                    "Refusing MCP environment variable '{key}' because it can alter the host \
+                     sandbox launcher's dynamic loader"
+                )));
+            }
+            if crate::tools::is_sensitive_env(key) && !sensitive_grants.contains(key) {
+                return Err(McpError::Transport(format!(
+                    "Refusing undeclared-sensitive MCP environment grant '{key}'. \
+                     The host operator must name it in OPENCLAUDIA_MCP_ENV_GRANTS."
+                )));
+            }
+        }
+        let security = crate::tools::security::current_context().map_err(McpError::Transport)?;
+        let sandbox_args: Vec<OsString> = args.iter().map(OsString::from).collect();
+        let command = crate::tools::sandboxed_process_command(
+            crate::tools::SandboxProfile::McpStdio,
+            resolved_command.as_os_str(),
+            &sandbox_args,
+            security.working_directory(),
+        )
+        .map_err(|error| {
+            McpError::Transport(format!("MCP stdio sandbox is unavailable: {error}"))
+        })?;
         info!(
-            command = %command,
-            args = ?args,
+            command = %resolved_command.display(),
+            arg_count = args.len(),
             env_vars = env.len(),
-            "Spawning MCP server"
+            profile = "mcp-stdio",
+            network = "disabled",
+            "Spawning sandboxed MCP server"
         );
 
-        let mut cmd = Command::new(command);
-        cmd.args(args)
-            .envs(
-                env.iter()
-                    .map(|(key, value)| (key.as_str(), value.as_str())),
-            )
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        let mut cmd = Command::from(command);
+        cmd.envs(
+            env.iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
         let mut child = cmd
             .spawn()
             .map_err(|e| McpError::Transport(format!("Failed to spawn process: {e}")))?;
+        let process_registration =
+            crate::tools::command::ActiveSandboxProcess::register(child.id().ok_or_else(|| {
+                McpError::Transport("Sandboxed MCP process has no process id".to_string())
+            })?);
 
         // Take stdout from the child once and wrap in a persistent BufReader
         let stdout = child
@@ -396,6 +431,7 @@ impl StdioTransport {
 
         Ok(Self {
             child: Arc::new(Mutex::new(child)),
+            _process_registration: process_registration,
             reader: Mutex::new(reader),
             request_id: AtomicU64::new(1),
             request_lock: Mutex::new(()), // Fix #732
@@ -483,6 +519,118 @@ impl StdioTransport {
 
         Ok(true)
     }
+}
+
+fn is_host_loader_environment(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    upper.starts_with("LD_")
+        || upper.starts_with("DYLD_")
+        || matches!(
+            upper.as_str(),
+            "GCONV_PATH" | "GLIBC_TUNABLES" | "LOCPATH" | "NLSPATH"
+        )
+}
+
+fn mcp_sensitive_environment_grants() -> Result<std::collections::HashSet<String>, McpError> {
+    let Some(raw) = std::env::var_os("OPENCLAUDIA_MCP_ENV_GRANTS") else {
+        return Ok(std::collections::HashSet::new());
+    };
+    let raw = raw.to_str().ok_or_else(|| {
+        McpError::Transport(
+            "OPENCLAUDIA_MCP_ENV_GRANTS contains non-Unicode data; MCP launch is blocked"
+                .to_string(),
+        )
+    })?;
+    raw.split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .try_fold(std::collections::HashSet::new(), |mut grants, name| {
+            let mut chars = name.chars();
+            let valid = chars
+                .next()
+                .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+                && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric());
+            if !valid {
+                return Err(McpError::Transport(format!(
+                    "Invalid environment variable name in OPENCLAUDIA_MCP_ENV_GRANTS: '{name}'"
+                )));
+            }
+            grants.insert(name.to_string());
+            Ok(grants)
+        })
+}
+
+fn resolve_trusted_mcp_executable(command: &str) -> Result<PathBuf, McpError> {
+    let candidate = if Path::new(command).is_absolute() {
+        PathBuf::from(command)
+    } else {
+        which::which(command).map_err(|error| {
+            McpError::Transport(format!(
+                "Cannot resolve MCP executable '{command}' from the host startup PATH: {error}"
+            ))
+        })?
+    };
+    let resolved = candidate.canonicalize().map_err(|error| {
+        McpError::Transport(format!(
+            "Cannot pin MCP executable '{}': {error}",
+            candidate.display()
+        ))
+    })?;
+    let metadata = std::fs::metadata(&resolved).map_err(|error| {
+        McpError::Transport(format!(
+            "Cannot inspect MCP executable '{}': {error}",
+            resolved.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(McpError::Transport(format!(
+            "MCP executable '{}' is not a regular file",
+            resolved.display()
+        )));
+    }
+    let security = crate::tools::security::current_context().map_err(McpError::Transport)?;
+    if security
+        .read_write_roots()
+        .iter()
+        .any(|root| resolved == *root || resolved.starts_with(root))
+    {
+        return Err(McpError::Transport(format!(
+            "Refusing MCP executable '{}' because it is inside an agent-writable capability root",
+            resolved.display()
+        )));
+    }
+    verify_trusted_executable_ancestry(&resolved)?;
+    Ok(resolved)
+}
+
+#[cfg(unix)]
+fn verify_trusted_executable_ancestry(path: &Path) -> Result<(), McpError> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    for component in path.ancestors() {
+        let metadata = std::fs::symlink_metadata(component).map_err(|error| {
+            McpError::Transport(format!(
+                "Cannot inspect MCP executable ancestry '{}': {error}",
+                component.display()
+            ))
+        })?;
+        if metadata.uid() != 0 || metadata.permissions().mode() & 0o022 != 0 {
+            return Err(McpError::Transport(format!(
+                "Refusing MCP executable '{}': component '{}' is not root-owned and non-writable by group/other",
+                path.display(),
+                component.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn verify_trusted_executable_ancestry(_path: &Path) -> Result<(), McpError> {
+    Err(McpError::Transport(
+        "MCP stdio is blocked: trusted executable ancestry verification is unsupported on this platform"
+            .to_string(),
+    ))
 }
 
 fn build_client_feature_response(id: u64, method: &str) -> Value {
@@ -1724,11 +1872,14 @@ fn run_headers_helper(
     env.insert("CLAUDE_CODE_MCP_SERVER_URL".to_string(), url.to_string());
 
     let (program, args) = shell_command(command);
+    let program = resolve_trusted_mcp_executable(program)?;
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    let output = crate::tools::command::run_with_timeout_with_env(
-        program,
+    let security = crate::tools::security::current_context().map_err(McpError::Transport)?;
+    let output = crate::tools::command::run_sandboxed_with_timeout_with_env(
+        crate::tools::SandboxProfile::McpStdio,
+        &program,
         &arg_refs,
-        None,
+        security.working_directory(),
         HEADERS_HELPER_TIMEOUT,
         &env,
     )

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -403,6 +403,30 @@ pub struct PluginMcpServer {
 }
 
 fn process_env_lookup(name: &str) -> Result<Option<String>, String> {
+    let grants = env::var_os("OPENCLAUDIA_MCP_ENV_GRANTS")
+        .map(|value| {
+            value
+                .to_str()
+                .ok_or_else(|| "OPENCLAUDIA_MCP_ENV_GRANTS contains non-Unicode data".to_string())
+                .and_then(|value| {
+                    value
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|entry| !entry.is_empty())
+                        .try_fold(std::collections::HashSet::new(), |mut grants, entry| {
+                            validate_mcp_env_var_name(entry)?;
+                            grants.insert(entry.to_string());
+                            Ok(grants)
+                        })
+                })
+        })
+        .transpose()?
+        .unwrap_or_default();
+    if !grants.contains(name) {
+        // An ungranted variable behaves as absent, allowing `${VAR:-safe}`
+        // defaults without exposing ambient host state.
+        return Ok(None);
+    }
     match env::var(name) {
         Ok(value) => Ok(Some(value)),
         Err(env::VarError::NotPresent) => Ok(None),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2423,8 +2423,60 @@ pub async fn connect_mcp_servers(
     mcp_manager: &Arc<RwLock<McpManager>>,
     plugin_manager: &Arc<PluginManager>,
 ) {
+    let trusted = match mcp_trust_grants_from_startup() {
+        Ok(trusted) => trusted,
+        Err(error) => {
+            warn!(
+                env = "OPENCLAUDIA_TRUST_MCP_SERVERS",
+                %error,
+                "MCP startup is blocked because the host trust grant is invalid"
+            );
+            return;
+        }
+    };
+    connect_mcp_servers_with_trust(mcp_manager, plugin_manager, &trusted).await;
+}
+
+/// Connect only MCP servers covered by an explicit host trust grant.
+///
+/// Entries use `plugin-id/server-name`. This function is public for trusted
+/// host frontends and integration tests; it is not part of agent tool
+/// dispatch.
+#[allow(clippy::too_many_lines)]
+pub async fn connect_mcp_servers_with_trust<S: std::hash::BuildHasher + Sync>(
+    mcp_manager: &Arc<RwLock<McpManager>>,
+    plugin_manager: &Arc<PluginManager>,
+    trusted: &std::collections::HashSet<String, S>,
+) {
     let mcp = mcp_manager.write().await;
     for (plugin, server) in plugin_manager.all_mcp_servers() {
+        let trust_id = format!("{}/{}", plugin.id, server.name);
+        if !trusted.contains(&trust_id) {
+            if let Err(error) = mcp.disconnect(&server.name).await {
+                warn!(
+                    server = %server.name,
+                    %error,
+                    "Failed to terminate MCP server while revoking trust"
+                );
+            }
+            warn!(
+                plugin = %plugin.id,
+                server = %server.name,
+                trust_id,
+                env = "OPENCLAUDIA_TRUST_MCP_SERVERS",
+                "MCP server remains disconnected pending an explicit host trust grant"
+            );
+            continue;
+        }
+        info!(
+            plugin = %plugin.id,
+            server = %server.name,
+            trust_id,
+            transport = %server.transport,
+            env_grants = server.env.len(),
+            header_grants = server.headers.len(),
+            "Applying explicit MCP server trust grant"
+        );
         let tool_timeout = server.timeout.map(std::time::Duration::from_millis);
         match server.transport.as_str() {
             "stdio" => {
@@ -2505,6 +2557,32 @@ pub async fn connect_mcp_servers(
     if count > 0 {
         info!(connected = count, "MCP servers initialized");
     }
+}
+
+fn mcp_trust_grants_from_startup() -> Result<std::collections::HashSet<String>, String> {
+    let Some(value) = std::env::var_os("OPENCLAUDIA_TRUST_MCP_SERVERS") else {
+        return Ok(std::collections::HashSet::new());
+    };
+    let value = value
+        .to_str()
+        .ok_or_else(|| "OPENCLAUDIA_TRUST_MCP_SERVERS contains non-Unicode data".to_string())?;
+    let mut trusted = std::collections::HashSet::new();
+    for entry in value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+    {
+        let valid = entry
+            .split_once('/')
+            .is_some_and(|(plugin, server)| !plugin.is_empty() && !server.is_empty());
+        if !valid || entry.contains('*') {
+            return Err(format!(
+                "invalid MCP trust id '{entry}'; expected exact plugin-id/server-name"
+            ));
+        }
+        trusted.insert(entry.to_string());
+    }
+    Ok(trusted)
 }
 
 /// Fire the `SessionStart` hook and return the session ID.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1660,8 +1660,7 @@ mod tests {
         for window in nums.windows(2) {
             assert!(
                 window[0] < window[1],
-                "turn_numbers must be strictly increasing after eviction: {:?}",
-                &window
+                "turn_numbers must be strictly increasing after eviction: {window:?}"
             );
         }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -844,8 +844,11 @@ impl SessionManager {
 
         // Persist the session; failure must surface to the caller, not be
         // swallowed via warn!() as it was prior to #356.
-        self.persist_session(&session)
-            .map_err(|source| EndSessionError::PersistFailed { source })?;
+        let persist_result = self.persist_session(&session);
+        crate::tools::cancel_session_sandbox_processes(&session.id);
+        crate::tools::terminate_session_background_jobs(&session.id);
+        crate::tools::security::release_session_context(&session.id);
+        persist_result.map_err(|source| EndSessionError::PersistFailed { source })?;
 
         info!(
             session_id = %session.id,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -81,7 +81,7 @@ mod tests {
         let state = SessionState::default();
         assert!(!state.identity.session_id.as_str().is_empty());
         assert!(state.conversation.messages.is_empty());
-        assert!(state.transcript.watermark == 0);
+        assert_eq!(state.transcript.watermark, 0);
     }
 
     #[test]

--- a/src/subagent.rs
+++ b/src/subagent.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write as _;
 use std::hash::BuildHasher;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard, Once};
 use std::time::{Duration, Instant};
@@ -40,8 +39,38 @@ fn git_bin() -> Result<&'static Path, String> {
     }
 }
 
-fn git_command() -> Result<Command, String> {
-    Ok(Command::new(git_bin()?))
+fn sandboxed_git(cwd: &Path, args: &[&str]) -> Result<std::process::Output, String> {
+    let mut hardened = vec![
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "diff.external=",
+        "-c",
+        "core.pager=cat",
+        "-c",
+        "credential.helper=",
+        "-c",
+        "protocol.file.allow=never",
+        "-c",
+        "protocol.ext.allow=never",
+    ];
+    hardened.extend_from_slice(args);
+    let env = HashMap::from([
+        ("GIT_CONFIG_GLOBAL".to_string(), "/dev/null".to_string()),
+        ("GIT_CONFIG_NOSYSTEM".to_string(), "1".to_string()),
+        ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
+    ]);
+    crate::tools::run_sandboxed_with_timeout_with_env(
+        crate::tools::SandboxProfile::GitWorktree,
+        git_bin()?,
+        &hardened,
+        cwd,
+        Duration::from_secs(30),
+        &env,
+    )
+    .map_err(|error| error.to_string())
 }
 
 fn agent_field_guard<'a, T>(
@@ -1014,12 +1043,9 @@ impl WorktreeIsolation {
         let branch_name = format!("agent/{agent_id}");
 
         // Find the git root
-        let git_root = git_command()
-            .and_then(|mut cmd| {
-                cmd.args(["rev-parse", "--show-toplevel"])
-                    .output()
-                    .map_err(|e| e.to_string())
-            })
+        let security = crate::tools::security::current_context()?;
+        let cwd = security.working_directory();
+        let git_root = sandboxed_git(cwd, &["rev-parse", "--show-toplevel"])
             .map_err(|e| format!("git not available: {e}"))?;
 
         if !git_root.status.success() {
@@ -1027,7 +1053,7 @@ impl WorktreeIsolation {
         }
 
         let root = String::from_utf8_lossy(&git_root.stdout).trim().to_string();
-        let worktree_dir = Path::new(&root).join(".openclaudia").join("worktrees");
+        let worktree_dir = Path::new(&root).join(".worktrees").join("subagents");
 
         // Ensure worktree directory exists
         std::fs::create_dir_all(&worktree_dir)
@@ -1036,16 +1062,10 @@ impl WorktreeIsolation {
         let worktree_path = worktree_dir.join(agent_id);
 
         // Create the worktree
-        let result = git_command()
-            .and_then(|mut cmd| {
-                cmd.arg("worktree")
-                    .arg("add")
-                    .arg(&worktree_path)
-                    .arg("-b")
-                    .arg(&branch_name)
-                    .output()
-                    .map_err(|e| e.to_string())
-            })
+        let worktree_arg = worktree_path
+            .to_str()
+            .ok_or_else(|| "worktree path must be valid UTF-8".to_string())?;
+        let result = sandboxed_git(cwd, &["worktree", "add", worktree_arg, "-b", &branch_name])
             .map_err(|e| format!("Failed to create worktree: {e}"))?;
 
         if !result.status.success() {
@@ -1062,12 +1082,15 @@ impl WorktreeIsolation {
     /// Check if the worktree has uncommitted changes
     #[must_use]
     pub fn has_changes(&self) -> bool {
-        let result = git_command().and_then(|mut cmd| {
-            cmd.arg("-C")
-                .arg(&self.worktree_path)
-                .args(["diff", "--stat"])
-                .output()
-                .map_err(|e| e.to_string())
+        let result = crate::tools::security::current_context().and_then(|security| {
+            let worktree = self
+                .worktree_path
+                .to_str()
+                .ok_or_else(|| "worktree path must be valid UTF-8".to_string())?;
+            sandboxed_git(
+                security.working_directory(),
+                &["-C", worktree, "diff", "--stat"],
+            )
         });
 
         match result {
@@ -1091,16 +1114,16 @@ impl WorktreeIsolation {
             ));
         }
 
-        let result = git_command()
-            .and_then(|mut cmd| {
-                cmd.arg("worktree")
-                    .arg("remove")
-                    .arg(&self.worktree_path)
-                    .arg("--force")
-                    .output()
-                    .map_err(|e| e.to_string())
-            })
-            .map_err(|e| format!("Failed to remove worktree: {e}"))?;
+        let security = crate::tools::security::current_context()?;
+        let worktree = self
+            .worktree_path
+            .to_str()
+            .ok_or_else(|| "worktree path must be valid UTF-8".to_string())?;
+        let result = sandboxed_git(
+            security.working_directory(),
+            &["worktree", "remove", worktree, "--force"],
+        )
+        .map_err(|e| format!("Failed to remove worktree: {e}"))?;
 
         if !result.status.success() {
             let stderr = String::from_utf8_lossy(&result.stderr);
@@ -1108,11 +1131,10 @@ impl WorktreeIsolation {
         }
 
         // Also delete the branch
-        let _ = git_command().and_then(|mut cmd| {
-            cmd.args(["branch", "-D", &self.branch_name])
-                .output()
-                .map_err(|e| e.to_string())
-        });
+        let _ = sandboxed_git(
+            security.working_directory(),
+            &["branch", "-D", &self.branch_name],
+        );
 
         Ok(())
     }

--- a/src/tools/bash/kill.rs
+++ b/src/tools/bash/kill.rs
@@ -41,6 +41,20 @@ pub fn execute_kill_shells_for_agent(args: &HashMap<String, Value>) -> (String, 
     if agent_id.is_empty() {
         return ("Missing 'agent_id' argument".to_string(), true);
     }
+    let caller = crate::tools::todo::current_session_key();
+    if agent_id != caller {
+        tracing::warn!(
+            target: "openclaudia::bash",
+            event = "cross_session_shell_cleanup_denied",
+            caller,
+            requested_owner = agent_id,
+            "Denied model-requested cleanup of another session's processes"
+        );
+        return (
+            "Cannot terminate background shells owned by another session".to_string(),
+            true,
+        );
+    }
 
     (BACKGROUND_SHELLS.kill_for_agent(agent_id), false)
 }
@@ -55,7 +69,12 @@ pub fn execute_kill_shells_for_agent(args: &HashMap<String, Value>) -> (String, 
 ///
 /// On Windows, uses `taskkill /T` which terminates the process tree.
 pub fn terminate_process_tree(pid: u32) {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
+    {
+        terminate_linux_process_tree(pid);
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
     {
         use std::time::{Duration, Instant};
 
@@ -128,6 +147,75 @@ pub fn terminate_process_tree(pid: u32) {
                 .output();
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn terminate_linux_process_tree(pid: u32) {
+    use std::collections::{HashSet, VecDeque};
+    use std::time::{Duration, Instant};
+
+    let Ok(root) = i32::try_from(pid) else {
+        return;
+    };
+    let descendants = || {
+        let mut found = Vec::new();
+        let mut seen = HashSet::from([root]);
+        let mut queue = VecDeque::from([root]);
+        while let Some(parent) = queue.pop_front() {
+            let task_dir = format!("/proc/{parent}/task");
+            let Ok(tasks) = std::fs::read_dir(task_dir) else {
+                continue;
+            };
+            for task in tasks.flatten() {
+                let children_path = task.path().join("children");
+                let Ok(children) = std::fs::read_to_string(children_path) else {
+                    continue;
+                };
+                for child in children
+                    .split_whitespace()
+                    .filter_map(|value| value.parse::<i32>().ok())
+                {
+                    if child > 0 && seen.insert(child) {
+                        found.push(child);
+                        queue.push_back(child);
+                    }
+                }
+            }
+        }
+        found
+    };
+    let signal_tree = |signal| {
+        let mut targets = descendants();
+        targets.reverse();
+        for target in targets {
+            unsafe {
+                libc::kill(target, signal);
+            }
+        }
+        // Also cover conventional process-group children, then the wrapper.
+        unsafe {
+            libc::kill(-root, signal);
+            libc::kill(root, signal);
+        }
+    };
+
+    signal_tree(libc::SIGTERM);
+    // A long grace period makes cancellation itself a denial-of-service
+    // vector, and a terminated-but-not-yet-reaped wrapper remains visible to
+    // `kill(pid, 0)` as a zombie. Give cooperative children a short grace,
+    // then deterministically escalate; the owning caller performs the reap.
+    let deadline = Instant::now() + Duration::from_millis(250);
+    while Instant::now() < deadline {
+        let root_exists = unsafe { libc::kill(root, 0) } == 0;
+        if !root_exists && descendants().is_empty() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    // Re-scan immediately before SIGKILL so children forked by a signal
+    // handler or daemonization attempt are included.
+    signal_tree(libc::SIGKILL);
+    std::thread::sleep(Duration::from_millis(100));
 }
 
 #[cfg(test)]

--- a/src/tools/bash/mod.rs
+++ b/src/tools/bash/mod.rs
@@ -1,6 +1,7 @@
 mod kill;
 mod output;
 pub mod path_constraints;
+pub mod sandbox;
 // `policy` is exposed so the security E2E test suite
 // (`tests/tools_security_e2e.rs`) can drive `validate_command`,
 // `is_safe_for_auto_allow`, `dangerous_shell_construct`, and
@@ -28,7 +29,7 @@ use std::io::{BufRead, BufReader, Read};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 use std::thread;
@@ -37,6 +38,8 @@ use uuid::Uuid;
 /// Maximum number of background shells allowed before refusing new ones
 const MAX_BACKGROUND_SHELLS: usize = 50;
 const LEDGER_COMMAND_OUTPUT_MAX_BYTES: usize = 100_000;
+const BACKGROUND_OUTPUT_MAX_BYTES_PER_STREAM: usize = 1024 * 1024;
+const FOREGROUND_COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(5);
 const VERIFICATION_COMMAND_NEEDLES: &[&str] = &[
     "cargo test",
     "cargo check",
@@ -72,10 +75,6 @@ fn bash_bin() -> Result<&'static Path, String> {
     }
 }
 
-fn bash_command() -> Result<Command, String> {
-    Ok(Command::new(bash_bin()?))
-}
-
 fn recover_mutex_lock<'a, T>(
     mutex: &'a Mutex<T>,
     op: &'static str,
@@ -95,9 +94,11 @@ fn recover_mutex_lock<'a, T>(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_output_reader<R>(
     stream: R,
     buffer: Arc<Mutex<Vec<String>>>,
+    output_limit: Arc<OutputLimit>,
     ledger_buffer: Arc<Mutex<String>>,
     done: Arc<AtomicBool>,
     op: &'static str,
@@ -110,10 +111,51 @@ fn spawn_output_reader<R>(
         let reader = BufReader::new(stream);
         for line in reader.lines().map_while(Result::ok) {
             append_ledger_output_line(&ledger_buffer, &line, op, "ledger_buffer", &shell_id);
-            recover_mutex_lock(&buffer, op, resource, Some(&shell_id)).push(line);
+            let retained = output_limit.reserve(line.len().saturating_add(1));
+            if retained > 0 {
+                let retained_line = safe_truncate(&line, retained.min(line.len())).to_string();
+                recover_mutex_lock(&buffer, op, resource, Some(&shell_id)).push(retained_line);
+            }
+            if retained < line.len().saturating_add(1)
+                && !output_limit.marker.swap(true, Ordering::SeqCst)
+            {
+                recover_mutex_lock(&buffer, op, resource, Some(&shell_id))
+                    .push("[output truncated at 1 MiB]".to_string());
+            }
         }
         done.store(true, Ordering::SeqCst);
     });
+}
+
+struct OutputLimit {
+    bytes: std::sync::atomic::AtomicUsize,
+    marker: AtomicBool,
+}
+
+impl OutputLimit {
+    const fn new() -> Self {
+        Self {
+            bytes: std::sync::atomic::AtomicUsize::new(0),
+            marker: AtomicBool::new(false),
+        }
+    }
+
+    fn reserve(&self, requested: usize) -> usize {
+        let mut current = self.bytes.load(Ordering::SeqCst);
+        loop {
+            let remaining = BACKGROUND_OUTPUT_MAX_BYTES_PER_STREAM.saturating_sub(current);
+            let granted = requested.min(remaining);
+            match self.bytes.compare_exchange(
+                current,
+                current.saturating_add(granted),
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return granted,
+                Err(actual) => current = actual,
+            }
+        }
+    }
 }
 
 fn append_ledger_output_line(
@@ -210,8 +252,8 @@ impl BackgroundShellManager {
 
         let shell_id = safe_truncate(&Uuid::new_v4().to_string(), 8).to_string();
         let owner = super::todo::current_session_key();
-        // IMPORTANT: Set current_dir to ensure bash runs in the same directory as the process
-        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let security = crate::tools::security::current_context()?;
+        let cwd = security.working_directory().to_path_buf();
 
         // ── Crosslink #672 fix: atomic check+reserve ──────────────────────────
         //
@@ -260,27 +302,18 @@ impl BackgroundShellManager {
 
         #[cfg(windows)]
         let child = {
-            let mut cmd = match find_git_bash() {
-                Some(git_bash) => Command::new(git_bash),
-                None => bash_command()?,
-            };
-            cmd.args(["-c", command])
-                .current_dir(&cwd)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-            apply_env_scrub(&mut cmd);
+            let bash = find_git_bash().unwrap_or(bash_bin()?.to_path_buf());
+            let mut cmd = sandbox::sandboxed_bash_command(&bash, command, &cwd)?;
+            cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
             cmd.spawn()
         };
 
         #[cfg(not(windows))]
         let child = {
-            let mut cmd = bash_command()?;
-            cmd.args(["-c", command])
-                .current_dir(&cwd)
-                .stdout(Stdio::piped())
+            let mut cmd = sandbox::sandboxed_bash_command(bash_bin()?, command, &cwd)?;
+            cmd.stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .process_group(0); // Put child in its own process group for clean kill
-            apply_env_scrub(&mut cmd);
             cmd.spawn()
         };
 
@@ -293,6 +326,8 @@ impl BackgroundShellManager {
         let stderr_buffer = Arc::new(Mutex::new(Vec::new()));
         let stdout_ledger_buffer = Arc::new(Mutex::new(String::new()));
         let stderr_ledger_buffer = Arc::new(Mutex::new(String::new()));
+        let stdout_output_limit = Arc::new(OutputLimit::new());
+        let stderr_output_limit = Arc::new(OutputLimit::new());
         let finished = Arc::new(AtomicBool::new(false));
         let stdout_done = Arc::new(AtomicBool::new(false));
         let stderr_done = Arc::new(AtomicBool::new(false));
@@ -314,6 +349,7 @@ impl BackgroundShellManager {
             spawn_output_reader(
                 stdout,
                 Arc::clone(&stdout_buffer),
+                stdout_output_limit,
                 Arc::clone(&stdout_ledger_buffer),
                 Arc::clone(&stdout_done),
                 "stdout_reader",
@@ -329,6 +365,7 @@ impl BackgroundShellManager {
             spawn_output_reader(
                 stderr,
                 Arc::clone(&stderr_buffer),
+                stderr_output_limit,
                 Arc::clone(&stderr_ledger_buffer),
                 Arc::clone(&stderr_done),
                 "stderr_reader",
@@ -419,6 +456,7 @@ impl BackgroundShellManager {
     /// Get output from a background shell (returns new output since last call)
     #[allow(clippy::significant_drop_tightening)] // shells lock must be held while accessing shell
     pub(crate) fn get_output(&self, shell_id: &str) -> Result<(String, bool, Option<i32>), String> {
+        let caller = super::todo::current_session_key();
         // Crosslink #678: the shells map holds an entry-per-shell HashMap with
         // no cross-field invariant — every recoverable state is fully
         // represented inside an individual BackgroundShell, and HashMap
@@ -431,6 +469,17 @@ impl BackgroundShellManager {
         let shell = shells
             .get(shell_id)
             .ok_or_else(|| format!("Shell '{shell_id}' not found"))?;
+        if shell.owner != caller {
+            tracing::warn!(
+                target: "openclaudia::bash",
+                event = "cross_session_shell_access_denied",
+                caller,
+                shell_id,
+                "Denied background shell output access outside the owning session"
+            );
+            // Deliberately do not reveal whether a guessed identifier exists.
+            return Err(format!("Shell '{shell_id}' not found"));
+        }
 
         let mut output = String::new();
 
@@ -509,6 +558,21 @@ impl BackgroundShellManager {
         // that observed poisoning.
         let mut shells = recover_mutex_lock(&self.shells, "kill", "shells", Some(shell_id));
 
+        let caller = super::todo::current_session_key();
+        if shells
+            .get(shell_id)
+            .is_some_and(|shell| shell.owner != caller)
+        {
+            tracing::warn!(
+                target: "openclaudia::bash",
+                event = "cross_session_shell_kill_denied",
+                caller,
+                shell_id,
+                "Denied background shell termination outside the owning session"
+            );
+            return Err(format!("Shell '{shell_id}' not found"));
+        }
+
         if let Some(shell) = shells.remove(shell_id) {
             if !shell.finished.load(Ordering::SeqCst) {
                 // Terminate the process group (SIGTERM -> wait -> SIGKILL)
@@ -572,10 +636,12 @@ impl BackgroundShellManager {
 
     /// List all background shells
     pub(crate) fn list(&self) -> Vec<(String, String, bool)> {
+        let caller = super::todo::current_session_key();
         // Crosslink #678: see get_output for poison-recovery rationale.
         let shells = recover_mutex_lock(&self.shells, "list", "shells", None);
         shells
             .iter()
+            .filter(|(_, shell)| shell.owner == caller)
             .map(|(id, shell)| {
                 (
                     id.clone(),
@@ -585,6 +651,20 @@ impl BackgroundShellManager {
             })
             .collect()
     }
+}
+
+/// Terminate every background job owned by a session during trusted lifecycle
+/// cleanup. This bypasses the agent-facing identifier argument, but remains
+/// scoped to the exact immutable session id supplied by `SessionManager`.
+pub fn terminate_session_background_jobs(session_id: &str) {
+    let result = BACKGROUND_SHELLS.kill_for_agent(session_id);
+    tracing::info!(
+        target: "openclaudia::bash",
+        event = "session_background_jobs_terminated",
+        session_id,
+        result,
+        "Applied session-end background-process cleanup"
+    );
 }
 
 fn wait_for_output_readers(stdout_done: &AtomicBool, stderr_done: &AtomicBool, shell_id: &str) {
@@ -731,27 +811,27 @@ pub fn try_execute_bash(args: &HashMap<String, Value>) -> Result<ToolOutput, Too
     // Run synchronously (original behavior).
     // On Windows, use Git Bash explicitly (not WSL bash).
     // On Unix, use system bash.
-    // IMPORTANT: Set current_dir to ensure bash runs in the same directory as
-    // the process.
-    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let security = crate::tools::security::current_context().map_err(ToolError::External)?;
+    let cwd = security.working_directory().to_path_buf();
 
     #[cfg(windows)]
     let output = {
-        let mut cmd = match find_git_bash() {
-            Some(git_bash) => Command::new(git_bash),
-            None => bash_command().map_err(ToolError::External)?,
-        };
-        cmd.args(["-c", command]).current_dir(&cwd);
-        apply_env_scrub(&mut cmd);
-        cmd.output()
+        let bash =
+            find_git_bash().unwrap_or(bash_bin().map_err(ToolError::External)?.to_path_buf());
+        let cmd =
+            sandbox::sandboxed_bash_command(&bash, command, &cwd).map_err(ToolError::External)?;
+        super::command::run_prepared_sandboxed_with_timeout(cmd, "bash", FOREGROUND_COMMAND_TIMEOUT)
     };
 
     #[cfg(not(windows))]
     let output = {
-        let mut cmd = bash_command().map_err(ToolError::External)?;
-        cmd.args(["-c", command]).current_dir(&cwd);
-        apply_env_scrub(&mut cmd);
-        cmd.output()
+        let cmd = sandbox::sandboxed_bash_command(
+            bash_bin().map_err(ToolError::External)?,
+            command,
+            &cwd,
+        )
+        .map_err(ToolError::External)?;
+        super::command::run_prepared_sandboxed_with_timeout(cmd, "bash", FOREGROUND_COMMAND_TIMEOUT)
     };
 
     let output =

--- a/src/tools/bash/policy.rs
+++ b/src/tools/bash/policy.rs
@@ -238,15 +238,9 @@ const ENV_ALLOWLIST_EXACT: &[&str] = &[
     "HOSTTYPE",
     "OSTYPE",
     "MACHTYPE",
-    "DISPLAY", // GUI sub-tools (xdg-open etc.)
-    "WAYLAND_DISPLAY",
     "COLORTERM",
-    "EDITOR",
-    "PAGER",
     "MANPATH",
     "INFOPATH",
-    "LD_LIBRARY_PATH",
-    "DYLD_LIBRARY_PATH",
     "PKG_CONFIG_PATH",
     // Rust toolchain — needed by cargo/rustc.
     "CARGO_HOME",
@@ -265,10 +259,7 @@ const ENV_ALLOWLIST_EXACT: &[&str] = &[
     // Node / Python / Go / Java — non-secret toolchain knobs.
     "NODE_ENV",
     "NPM_CONFIG_PREFIX",
-    "NPM_CONFIG_USERCONFIG",
     "NVM_DIR",
-    "PYTHONPATH",
-    "PYTHONHOME",
     "VIRTUAL_ENV",
     "PIPENV_VENV_IN_PROJECT",
     "POETRY_HOME",
@@ -276,7 +267,6 @@ const ENV_ALLOWLIST_EXACT: &[&str] = &[
     "JDK_HOME",
     "GOPATH",
     "GOROOT",
-    "GOPROXY",
     // CI introspection (presence-only, not credentials).
     "CI",
     // Locale fallbacks beyond LC_*.
@@ -292,17 +282,14 @@ const ENV_ALLOWLIST_EXACT: &[&str] = &[
 /// would subsume `CARGO_REGISTRY_TOKEN`, so we exclude that prefix and
 /// instead enumerate the safe CARGO_* knobs in [`ENV_ALLOWLIST_EXACT`].
 const ENV_ALLOWLIST_PREFIXES: &[&str] = &[
-    "LC_",   // locale families: LC_CTYPE, LC_NUMERIC, LC_TIME, ...
-    "XDG_",  // freedesktop base-dir spec: XDG_RUNTIME_DIR, XDG_CONFIG_HOME, ...
-    "SSH_",  // SSH agent socket / TTY — names only, no SSH_PRIVATE_KEY (caught by suffix).
-    "DBUS_", // session bus address (Linux desktop integration).
+    "LC_", // locale families: LC_CTYPE, LC_NUMERIC, LC_TIME, ...
 ];
 
 /// True if `key` is on the allowlist AND is not classified as sensitive.
 ///
 /// The sensitivity check is a belt-and-braces second gate so that even if
 /// a future allowlist entry accidentally subsumes a credential family
-/// (e.g. someone adds `SSH_` and `SSH_PRIVATE_KEY` snuck through), the
+/// (e.g. someone adds a broad prefix and `SSH_PRIVATE_KEY` snuck through), the
 /// suffix/prefix denylist in [`is_sensitive_env`] still drops it.
 #[must_use]
 pub fn is_env_allowed(key: &str) -> bool {
@@ -1092,17 +1079,17 @@ mod tests {
         }
     }
 
-    /// #730-d: prefix families (LC_*, XDG_*) are inherited; `SSH_PRIVATE_KEY`
-    /// is NOT (sensitive denylist overrides allowlist prefix SSH_).
+    /// Only locale prefixes are inherited. Desktop/IPC prefix families remain
+    /// denied even when their individual values do not look secret.
     #[test]
     fn allowlist_prefix_families_and_belt_and_braces() {
         assert!(is_env_allowed("LC_CTYPE"));
         assert!(is_env_allowed("LC_NUMERIC"));
-        assert!(is_env_allowed("XDG_RUNTIME_DIR"));
-        assert!(is_env_allowed("XDG_CONFIG_HOME"));
-        assert!(is_env_allowed("SSH_AUTH_SOCK"));
-        // Belt-and-braces: even though the SSH_ prefix matches, the
-        // sensitive denylist drops SSH_PRIVATE_KEY first.
+        assert!(!is_env_allowed("XDG_RUNTIME_DIR"));
+        assert!(!is_env_allowed("XDG_CONFIG_HOME"));
+        assert!(!is_env_allowed("SSH_AUTH_SOCK"));
+        assert!(!is_env_allowed("DBUS_SESSION_BUS_ADDRESS"));
+        // Belt-and-braces: sensitive names remain denied independently.
         assert!(
             !is_env_allowed("SSH_PRIVATE_KEY"),
             "#730: is_sensitive_env must override allowlist prefix"

--- a/src/tools/bash/sandbox.rs
+++ b/src/tools/bash/sandbox.rs
@@ -35,7 +35,14 @@ const SECCOMP_FILTER_FD: libc::c_int = 198;
 const MAX_PROJECT_SCAN_ENTRIES: usize = 1_000_000;
 
 #[cfg(target_os = "linux")]
-static BWRAP_BIN: LazyLock<Result<PathBuf, String>> = LazyLock::new(find_bwrap);
+#[derive(Clone, Debug)]
+struct BubblewrapBackend {
+    path: PathBuf,
+    share_network_namespace: bool,
+}
+
+#[cfg(target_os = "linux")]
+static BWRAP_BACKEND: LazyLock<Result<BubblewrapBackend, String>> = LazyLock::new(find_bwrap);
 static SANDBOX_DISABLED: LazyLock<Result<bool, String>> =
     LazyLock::new(sandbox_explicitly_disabled_from_env);
 
@@ -104,7 +111,7 @@ pub fn sandbox_diagnostics() -> SandboxDiagnostics {
     #[cfg(target_os = "linux")]
     let (backend, result, syscall_filter) = (
         "bubblewrap",
-        BWRAP_BIN.as_ref().map(|_| ()).map_err(Clone::clone),
+        BWRAP_BACKEND.as_ref().map(|_| ()).map_err(Clone::clone),
         "seccomp-v1",
     );
     #[cfg(target_os = "macos")]
@@ -383,7 +390,7 @@ fn linux_bubblewrap_command(
     cwd: &Path,
 ) -> Result<Command, String> {
     let cwd = canonical_working_directory(cwd)?;
-    let bwrap = BWRAP_BIN.as_ref().map_err(Clone::clone)?;
+    let backend = BWRAP_BACKEND.as_ref().map_err(Clone::clone)?;
     let security = crate::tools::security::current_context()?;
     if !security.permits_read(&cwd) {
         return Err(format!(
@@ -426,11 +433,12 @@ fn linux_bubblewrap_command(
         .unwrap_or_else(|| PathBuf::from("/home/openclaudia"));
     let pinned_bind_roots = security.duplicate_linux_bind_roots()?;
     let mut metadata_bind_fds = Vec::new();
-    let mut cmd = Command::new(bwrap);
+    let mut cmd = Command::new(&backend.path);
+    cmd.args(["--die-with-parent", "--new-session", "--unshare-all"]);
+    if backend.share_network_namespace {
+        cmd.arg("--share-net");
+    }
     cmd.args([
-        "--die-with-parent",
-        "--new-session",
-        "--unshare-all",
         "--unshare-user",
         "--disable-userns",
         "--assert-userns-disabled",
@@ -598,7 +606,7 @@ fn canonical_working_directory(cwd: &Path) -> Result<PathBuf, String> {
 }
 
 #[cfg(target_os = "linux")]
-fn find_bwrap() -> Result<PathBuf, String> {
+fn find_bwrap() -> Result<BubblewrapBackend, String> {
     const TRUSTED_LOCATIONS: &[&str] = &[
         "/usr/bin/bwrap",
         "/usr/sbin/bwrap",
@@ -621,8 +629,23 @@ fn find_bwrap() -> Result<PathBuf, String> {
                     resolved.display()
                 ));
             }
-            probe_bwrap(&resolved)?;
-            return Ok(resolved);
+            let share_network_namespace = match probe_bwrap(&resolved, false) {
+                Ok(()) => false,
+                Err(error) if is_network_namespace_probe_failure(&error) => {
+                    probe_bwrap(&resolved, true).map_err(|fallback_error| {
+                        format!(
+                            "{error}; Bubblewrap also failed with the seccomp-enforced network \
+                             fallback: {fallback_error}"
+                        )
+                    })?;
+                    true
+                }
+                Err(error) => return Err(error),
+            };
+            return Ok(BubblewrapBackend {
+                path: resolved,
+                share_network_namespace,
+            });
         }
     }
     Err(format!(
@@ -633,7 +656,7 @@ fn find_bwrap() -> Result<PathBuf, String> {
 }
 
 #[cfg(target_os = "linux")]
-fn probe_bwrap(bwrap: &Path) -> Result<(), String> {
+fn probe_bwrap(bwrap: &Path, share_network_namespace: bool) -> Result<(), String> {
     let true_bin = ["/usr/bin/true", "/bin/true"]
         .iter()
         .map(Path::new)
@@ -648,12 +671,15 @@ fn probe_bwrap(bwrap: &Path) -> Result<(), String> {
     );
     let root_fd = root.as_raw_fd();
     let root_for_child = Arc::clone(&root);
+    let filter = Arc::new(linux_seccomp_filter()?);
+    let filter_for_child = Arc::clone(&filter);
     let mut command = Command::new(bwrap);
+    command.args(["--die-with-parent", "--new-session", "--unshare-all"]);
+    if share_network_namespace {
+        command.arg("--share-net");
+    }
     command
         .args([
-            "--die-with-parent",
-            "--new-session",
-            "--unshare-all",
             "--unshare-user",
             "--disable-userns",
             "--assert-userns-disabled",
@@ -662,7 +688,16 @@ fn probe_bwrap(bwrap: &Path) -> Result<(), String> {
             "--ro-bind-fd",
         ])
         .arg(root_fd.to_string())
-        .args(["/", "--proc", "/proc", "--dev", "/dev", "--"])
+        .args([
+            "/",
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--seccomp",
+            "198",
+            "--",
+        ])
         .arg(true_bin)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -671,11 +706,11 @@ fn probe_bwrap(bwrap: &Path) -> Result<(), String> {
     // descriptor until spawn completes.
     unsafe {
         command.pre_exec(move || {
-            if libc::fcntl(root_for_child.as_raw_fd(), libc::F_SETFD, 0) == 0 {
-                Ok(())
-            } else {
-                Err(std::io::Error::last_os_error())
+            if libc::fcntl(root_for_child.as_raw_fd(), libc::F_SETFD, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
             }
+            install_seccomp_filter_fd(&filter_for_child)?;
+            close_inherited_file_descriptors(&[root_for_child.as_raw_fd(), SECCOMP_FILTER_FD])
         });
     }
     let output = command.output().map_err(|error| {
@@ -694,6 +729,13 @@ fn probe_bwrap(bwrap: &Path) -> Result<(), String> {
          ({category}, status {}): {diagnostic}",
         output.status,
     ))
+}
+
+#[cfg(target_os = "linux")]
+fn is_network_namespace_probe_failure(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("loopback")
+        && (lower.contains("rtm_newaddr") || lower.contains("operation not permitted"))
 }
 
 #[cfg(target_os = "linux")]
@@ -1472,6 +1514,30 @@ mod tests {
             classify_bwrap_probe_failure("mount source failed"),
             "required mount behavior unavailable"
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn network_namespace_fallback_only_accepts_loopback_setup_failures() {
+        assert!(is_network_namespace_probe_failure(
+            "bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted"
+        ));
+        assert!(!is_network_namespace_probe_failure(
+            "Creating new namespace failed: Operation not permitted"
+        ));
+        assert!(!is_network_namespace_probe_failure(
+            "bwrap: Can't mount proc on /newroot/proc: Operation not permitted"
+        ));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn seccomp_network_fallback_probe_is_usable() {
+        let backend = BWRAP_BACKEND
+            .as_ref()
+            .expect("Bubblewrap backend must be usable");
+        probe_bwrap(&backend.path, true)
+            .expect("shared network namespace must remain blocked by the seccomp filter");
     }
 
     #[test]

--- a/src/tools/bash/sandbox.rs
+++ b/src/tools/bash/sandbox.rs
@@ -1,0 +1,1569 @@
+//! OS-level containment for model-supplied shell commands.
+//!
+//! Shell parsing is intentionally not part of the security boundary. A model
+//! can reach the same syscall through parameter expansion, an interpreter, a
+//! compiler, or a freshly-written executable, so command/path denylists cannot
+//! contain it. On Linux we instead execute every Bash tool call in a
+//! bubblewrap-created set of namespaces with an allowlisted filesystem.
+
+#[cfg(target_os = "linux")]
+use std::collections::{HashMap, HashSet};
+use std::ffi::{OsStr, OsString};
+#[cfg(target_os = "linux")]
+use std::fs;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
+#[cfg(target_os = "linux")]
+use std::os::{
+    fd::{AsRawFd as _, FromRawFd as _, OwnedFd},
+    unix::ffi::OsStrExt as _,
+};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+const DISABLE_ENV: &str = "OPENCLAUDIA_BASH_SANDBOX";
+#[cfg(target_os = "linux")]
+const SECCOMP_FILTER_FD: libc::c_int = 198;
+#[cfg(target_os = "linux")]
+const MAX_PROJECT_SCAN_ENTRIES: usize = 1_000_000;
+
+#[cfg(target_os = "linux")]
+static BWRAP_BIN: LazyLock<Result<PathBuf, String>> = LazyLock::new(find_bwrap);
+static SANDBOX_DISABLED: LazyLock<Result<bool, String>> =
+    LazyLock::new(sandbox_explicitly_disabled_from_env);
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+enum ControlPathAccess {
+    Hidden,
+    ReadOnly,
+}
+
+/// Named policy profiles for agent-influenced subprocess classes.
+#[derive(Clone, Copy, Debug)]
+pub enum SandboxProfile {
+    Shell,
+    RepositoryHook,
+    LanguageServer,
+    StaticAnalyzer,
+    QualityGate,
+    DocumentParser,
+    McpStdio,
+    GitWorktree,
+}
+
+/// Redacted status for operator diagnostics. Counts and policy states are
+/// exposed; environment values and credential material never are.
+#[derive(Clone, Debug)]
+pub struct SandboxDiagnostics {
+    pub backend: &'static str,
+    pub healthy: bool,
+    pub detail: String,
+    pub network: &'static str,
+    pub syscall_filter: &'static str,
+    pub resource_limits: &'static str,
+    pub explicit_host_opt_out: bool,
+    pub read_only_root_count: usize,
+    pub read_write_root_count: usize,
+    pub environment_grant_count: usize,
+}
+
+/// Probe the active backend and summarize the effective default policy.
+#[must_use]
+pub fn sandbox_diagnostics() -> SandboxDiagnostics {
+    let disabled = SANDBOX_DISABLED.as_ref().copied().unwrap_or(false);
+    let context = crate::tools::security::current_context().ok();
+    let (read_only_root_count, read_write_root_count) = context.as_ref().map_or((0, 0), |ctx| {
+        (ctx.read_only_roots().len(), ctx.read_write_roots().len())
+    });
+    let environment_grant_count = context
+        .as_ref()
+        .map_or(0, |ctx| ctx.environment_grants().len());
+    if disabled {
+        return SandboxDiagnostics {
+            backend: "host-opt-out",
+            healthy: true,
+            detail: format!("{DISABLE_ENV}=off was set by the host operator"),
+            network: "host (UNRESTRICTED)",
+            syscall_filter: "disabled",
+            resource_limits: "disabled",
+            explicit_host_opt_out: true,
+            read_only_root_count,
+            read_write_root_count,
+            environment_grant_count,
+        };
+    }
+
+    #[cfg(target_os = "linux")]
+    let (backend, result, syscall_filter) = (
+        "bubblewrap",
+        BWRAP_BIN.as_ref().map(|_| ()).map_err(Clone::clone),
+        "seccomp-v1",
+    );
+    #[cfg(target_os = "macos")]
+    let (backend, result, syscall_filter) = (
+        "macos-unavailable",
+        Err(
+            "No maintained OS-supported macOS subprocess sandbox backend is available in this build"
+                .to_string(),
+        ),
+        "unavailable",
+    );
+    #[cfg(windows)]
+    let (backend, result, syscall_filter) = (
+        "windows-appcontainer",
+        Err("AppContainer backend is unavailable in this build".to_string()),
+        "unavailable",
+    );
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    let (backend, result, syscall_filter) = (
+        "unsupported",
+        Err(format!(
+            "No sandbox backend is implemented for {}",
+            std::env::consts::OS
+        )),
+        "unavailable",
+    );
+    let (healthy, detail) = match result {
+        Ok(()) => (true, "backend health probe passed".to_string()),
+        Err(error) => (false, redact_diagnostic(&error)),
+    };
+    SandboxDiagnostics {
+        backend,
+        healthy,
+        detail,
+        network: "denied",
+        syscall_filter,
+        resource_limits: if cfg!(target_os = "linux") {
+            "cpu=300s, address-space=4GiB, processes=host-baseline+256, files=1024, file-size=256MiB"
+        } else {
+            "unavailable (agent subprocesses fail closed)"
+        },
+        explicit_host_opt_out: false,
+        read_only_root_count,
+        read_write_root_count,
+        environment_grant_count,
+    }
+}
+
+/// Fail closed during startup when an agent-capable surface has no usable
+/// backend. This forces backend failures to appear before the first tool call.
+///
+/// # Errors
+///
+/// Returns a redacted actionable diagnostic when the configured platform
+/// backend is unavailable, unhealthy, or explicitly misconfigured.
+pub fn sandbox_preflight() -> Result<(), String> {
+    let diagnostics = sandbox_diagnostics();
+    if diagnostics.healthy {
+        if diagnostics.explicit_host_opt_out {
+            tracing::warn!(
+                target: "openclaudia::sandbox",
+                event = "sandbox_host_opt_out",
+                "Host operator explicitly disabled agent process isolation"
+            );
+        } else {
+            tracing::info!(
+                target: "openclaudia::sandbox",
+                event = "sandbox_preflight_passed",
+                backend = diagnostics.backend,
+                network = diagnostics.network,
+                syscall_filter = diagnostics.syscall_filter,
+                resource_limits = diagnostics.resource_limits,
+                "Agent sandbox preflight passed"
+            );
+        }
+        Ok(())
+    } else {
+        tracing::error!(
+            target: "openclaudia::sandbox",
+            event = "sandbox_preflight_failed",
+            backend = diagnostics.backend,
+            detail = diagnostics.detail,
+            "Agent sandbox preflight failed closed"
+        );
+        Err(format!(
+            "Agent execution is unavailable: {} backend failed its startup health check: {}",
+            diagnostics.backend, diagnostics.detail
+        ))
+    }
+}
+
+fn redact_diagnostic(value: &str) -> String {
+    let mut redacted = String::with_capacity(value.len().min(512));
+    for token in value.split_whitespace() {
+        if token.starts_with('/') || token.contains('=') {
+            redacted.push_str("[redacted] ");
+        } else {
+            redacted.push_str(token);
+            redacted.push(' ');
+        }
+        if redacted.len() >= 512 {
+            break;
+        }
+    }
+    redacted.trim().to_string()
+}
+
+#[cfg(target_os = "linux")]
+impl SandboxProfile {
+    const fn control_path_access(self) -> ControlPathAccess {
+        if matches!(self, Self::RepositoryHook) {
+            ControlPathAccess::ReadOnly
+        } else {
+            ControlPathAccess::Hidden
+        }
+    }
+
+    const fn permits_project_path(self) -> bool {
+        matches!(
+            self,
+            Self::Shell
+                | Self::RepositoryHook
+                | Self::LanguageServer
+                | Self::StaticAnalyzer
+                | Self::QualityGate
+        )
+    }
+}
+
+/// Build the command used for a model-supplied Bash invocation.
+///
+/// The opt-out is deliberately process-level only. Tool arguments are hostile
+/// input and can never select the unsandboxed branch.
+pub(super) fn sandboxed_bash_command(
+    bash: &Path,
+    command: &str,
+    cwd: &Path,
+) -> Result<Command, String> {
+    sandboxed_process_command(
+        SandboxProfile::Shell,
+        bash.as_os_str(),
+        &[OsString::from("-c"), OsString::from(command)],
+        cwd,
+    )
+}
+
+/// Build an OS-contained process command for code that may have been
+/// influenced by project content (quality gates, compilers, and similar).
+pub fn sandboxed_process_command(
+    profile: SandboxProfile,
+    program: &OsStr,
+    args: &[OsString],
+    cwd: &Path,
+) -> Result<Command, String> {
+    sandboxed_process_command_for_profile(profile, program, args, cwd)
+}
+
+/// Contain a user-configured hook while leaving its control-directory scripts
+/// readable. The source command's explicit environment changes are preserved
+/// on top of the sandbox's allowlisted environment.
+pub fn sandboxed_hook_command(source: &Command, cwd: &Path) -> Result<Command, String> {
+    let args: Vec<OsString> = source.get_args().map(OsString::from).collect();
+    let mut command = sandboxed_process_command_for_profile(
+        SandboxProfile::RepositoryHook,
+        source.get_program(),
+        &args,
+        cwd,
+    )?;
+    for (key, value) in source.get_envs() {
+        if let Some(value) = value {
+            command.env(key, value);
+        } else {
+            command.env_remove(key);
+        }
+    }
+    Ok(command)
+}
+
+fn sandboxed_process_command_for_profile(
+    profile: SandboxProfile,
+    program: &OsStr,
+    args: &[OsString],
+    cwd: &Path,
+) -> Result<Command, String> {
+    if *SANDBOX_DISABLED.as_ref().map_err(Clone::clone)? {
+        static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+        if !WARNED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            tracing::warn!(
+                target: "openclaudia::bash",
+                env = DISABLE_ENV,
+                "Bash OS sandbox explicitly disabled by the host user; model commands have host access"
+            );
+        }
+        return unsandboxed_process_command(program, args, cwd);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        linux_bubblewrap_command(profile, program, args, cwd)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (profile, program, args, cwd);
+        Err(format!(
+            "Agent subprocess execution is blocked on macOS: the deprecated sandbox-exec \
+             interface is not accepted as a production security boundary, and this build has \
+             no signed helper sandbox. OpenClaudia will not fall back to host execution. \
+             A host user may explicitly accept the risk with {DISABLE_ENV}=off"
+        ))
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = (profile, program, args, cwd);
+        Err(format!(
+            "Agent subprocess execution is blocked: the Windows AppContainer backend is not \
+             available in this build. OpenClaudia will not fall back to host execution. \
+             A host user may explicitly accept the risk with {DISABLE_ENV}=off"
+        ))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        let _ = (profile, program, args, cwd);
+        Err(format!(
+            "Agent subprocess execution is blocked: {} has no supported OpenClaudia sandbox \
+             backend, and host execution is never selected automatically. A host user may \
+             explicitly accept the risk with {DISABLE_ENV}=off",
+            std::env::consts::OS
+        ))
+    }
+}
+
+fn sandbox_explicitly_disabled_from_env() -> Result<bool, String> {
+    std::env::var_os(DISABLE_ENV).map_or(Ok(false), |value| {
+        value.to_str().map_or_else(
+            || {
+                Err(format!(
+                    "{DISABLE_ENV} contains non-Unicode data; refusing to weaken the Bash sandbox"
+                ))
+            },
+            sandbox_explicitly_disabled_value,
+        )
+    })
+}
+
+fn sandbox_explicitly_disabled_value(value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "on" | "1" | "true" | "required" => Ok(false),
+        "off" | "0" | "false" | "disabled" => Ok(true),
+        _ => Err(format!(
+            "Invalid {DISABLE_ENV} value '{value}'; use 'on' (default) or 'off'"
+        )),
+    }
+}
+
+fn unsandboxed_process_command(
+    program: &OsStr,
+    args: &[OsString],
+    cwd: &Path,
+) -> Result<Command, String> {
+    let cwd = canonical_working_directory(cwd)?;
+    let mut cmd = Command::new(program);
+    cmd.args(args).current_dir(cwd);
+    super::apply_env_scrub(&mut cmd);
+    Ok(cmd)
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_lines)]
+fn linux_bubblewrap_command(
+    profile: SandboxProfile,
+    program: &OsStr,
+    args: &[OsString],
+    cwd: &Path,
+) -> Result<Command, String> {
+    let cwd = canonical_working_directory(cwd)?;
+    let bwrap = BWRAP_BIN.as_ref().map_err(Clone::clone)?;
+    let security = crate::tools::security::current_context()?;
+    if !security.permits_read(&cwd) {
+        return Err(format!(
+            "Sandbox working directory '{}' is outside the immutable session capabilities rooted at '{}'",
+            cwd.display(),
+            security.project_root().display()
+        ));
+    }
+    let project_root = security.project_root();
+    let host_home = dirs::home_dir().and_then(|path| path.canonicalize().ok());
+
+    // A writable bind of HOME (or an ancestor of it) would make the nominal
+    // "project" mount expose credentials and host configuration.
+    if is_unsafe_broad_project_root(project_root)
+        || host_home
+            .as_ref()
+            .is_some_and(|home| home == project_root || home.starts_with(project_root))
+    {
+        return Err(format!(
+            "Refusing to sandbox Bash with working directory '{}': choose a dedicated \
+             project directory, not a broad system root or an ancestor of the user home",
+            project_root.display()
+        ));
+    }
+    for writable_root in security.read_write_roots() {
+        validate_writable_project_tree(writable_root)?;
+    }
+    tracing::debug!(
+        session_id = security.session_id(),
+        project_root = %project_root.display(),
+        working_directory = %cwd.display(),
+        read_only_roots = security.read_only_roots().len(),
+        read_write_roots = security.read_write_roots().len(),
+        profile = ?profile,
+        "Building agent subprocess sandbox from immutable session capabilities"
+    );
+
+    let sandbox_home = host_home
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("/home/openclaudia"));
+    let pinned_bind_roots = security.duplicate_linux_bind_roots()?;
+    let mut metadata_bind_fds = Vec::new();
+    let mut cmd = Command::new(bwrap);
+    cmd.args([
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+        "--unshare-user",
+        "--disable-userns",
+        "--assert-userns-disabled",
+        "--cap-drop",
+        "ALL",
+        "--hostname",
+        "openclaudia-sandbox",
+        "--seccomp",
+        "198",
+    ]);
+
+    // Start from an empty root and add only runtime trees. In particular,
+    // host /etc, /home, /root, /run, /tmp, /var, /proc and /sys are not
+    // inherited.
+    add_read_only_tree_if_present(&mut cmd, Path::new("/usr"));
+    add_read_only_tree_if_present(&mut cmd, Path::new("/nix/store"));
+    add_read_only_tree_if_present(&mut cmd, Path::new("/nix/var/nix/profiles"));
+    add_runtime_alias(&mut cmd, "/bin", "usr/bin");
+    add_runtime_alias(&mut cmd, "/sbin", "usr/sbin");
+    add_runtime_alias(&mut cmd, "/lib", "usr/lib");
+    add_runtime_alias(&mut cmd, "/lib64", "usr/lib64");
+    cmd.args([
+        "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp", "--tmpfs", "/run",
+    ]);
+
+    let mut made_dirs = HashSet::new();
+    add_directory_ancestors(&mut cmd, &mut made_dirs, &sandbox_home);
+
+    // Make common local toolchains available without exposing the rest of
+    // HOME. Cargo's directory itself stays writable tmpfs for lock/cache
+    // metadata; binaries and the registry cache are nested read-only binds.
+    let sandbox_cargo = sandbox_home.join(".cargo");
+    add_directory(&mut cmd, &mut made_dirs, &sandbox_cargo);
+    if let Some(home) = &host_home {
+        add_read_only_tree_if_present(&mut cmd, &home.join(".cargo/bin"));
+        add_read_only_tree_if_present(&mut cmd, &home.join(".cargo/registry"));
+        add_read_only_tree_if_present(&mut cmd, &home.join(".rustup"));
+    }
+
+    for root in &pinned_bind_roots {
+        add_directory_ancestors(&mut cmd, &mut made_dirs, &root.path);
+        cmd.arg(if root.writable {
+            "--bind-fd"
+        } else {
+            "--ro-bind-fd"
+        })
+        .arg(root.directory.as_raw_fd().to_string())
+        .arg(&root.path);
+    }
+
+    // Repository metadata and harness control state are not ordinary project
+    // output. A shell must not persist hooks/configuration that execute after
+    // the sandbox exits, or read transcripts and local agent state.
+    if matches!(profile, SandboxProfile::GitWorktree) {
+        tracing::info!(
+            target: "openclaudia::sandbox",
+            event = "git_metadata_write_grant",
+            session_id = security.session_id(),
+            "Git worktree profile received project-local metadata write access"
+        );
+    } else {
+        protect_repository_metadata(
+            &mut cmd,
+            &mut made_dirs,
+            &mut metadata_bind_fds,
+            project_root,
+        )?;
+    }
+    match profile.control_path_access() {
+        ControlPathAccess::Hidden => {
+            hide_control_path(&mut cmd, &project_root.join(".openclaudia"));
+            hide_control_path(&mut cmd, &project_root.join(".claude"));
+        }
+        ControlPathAccess::ReadOnly => {
+            for control_path in [
+                project_root.join(".openclaudia"),
+                project_root.join(".claude"),
+            ] {
+                if control_path.exists() {
+                    add_pinned_read_only_bind(&mut cmd, &mut metadata_bind_fds, &control_path)?;
+                }
+            }
+        }
+    }
+    for denied_path in security.denied_paths() {
+        if denied_path != &project_root.join(".openclaudia")
+            && denied_path != &project_root.join(".claude")
+        {
+            hide_control_path(&mut cmd, denied_path);
+        }
+    }
+
+    let safe_path = sandbox_path(
+        project_root,
+        host_home.as_deref(),
+        profile.permits_project_path(),
+    );
+    let private_temp = security.private_temp_root();
+    cmd.arg("--chdir")
+        .arg(&cwd)
+        .args(["--setenv", "HOME"])
+        .arg(&sandbox_home)
+        .args(["--setenv", "TMPDIR"])
+        .arg(private_temp)
+        .args(["--setenv", "TMP"])
+        .arg(private_temp)
+        .args(["--setenv", "TEMP"])
+        .arg(private_temp)
+        .args(["--setenv", "CARGO_HOME"])
+        .arg(&sandbox_cargo)
+        .args(["--setenv", "RUSTUP_HOME"])
+        .arg(sandbox_home.join(".rustup"))
+        .args(["--setenv", "PATH", &safe_path])
+        .args(["--setenv", "XDG_CONFIG_HOME", "/tmp/xdg/config"])
+        .args(["--setenv", "XDG_CACHE_HOME", "/tmp/xdg/cache"])
+        .args(["--setenv", "XDG_DATA_HOME", "/tmp/xdg/data"])
+        .args(["--setenv", "OPENCLAUDIA_SANDBOX", "1"])
+        // Do not carry pointers to host IPC endpoints into the namespace.
+        .args(["--unsetenv", "SSH_AUTH_SOCK"])
+        .args(["--unsetenv", "SSH_AGENT_PID"])
+        .args(["--unsetenv", "DBUS_SESSION_BUS_ADDRESS"])
+        .args(["--unsetenv", "DISPLAY"])
+        .args(["--unsetenv", "WAYLAND_DISPLAY"])
+        .args(["--unsetenv", "XDG_RUNTIME_DIR"])
+        .args(["--"])
+        .arg(program)
+        .args(args)
+        .current_dir(&cwd);
+    super::apply_env_scrub(&mut cmd);
+    for (key, value) in security.environment_grants() {
+        cmd.env(key, value);
+    }
+    let inherited_bind_fds = pinned_bind_roots
+        .into_iter()
+        .map(|root| root.directory)
+        .chain(metadata_bind_fds)
+        .collect();
+    install_linux_process_hardening(&mut cmd, inherited_bind_fds)?;
+    Ok(cmd)
+}
+
+#[cfg(target_os = "linux")]
+fn is_unsafe_broad_project_root(path: &Path) -> bool {
+    const BROAD_ROOTS: &[&str] = &[
+        "/", "/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib64", "/media", "/mnt", "/opt",
+        "/proc", "/root", "/run", "/sbin", "/srv", "/sys", "/tmp", "/usr", "/var",
+    ];
+    BROAD_ROOTS.iter().any(|root| path == Path::new(root))
+}
+
+fn canonical_working_directory(cwd: &Path) -> Result<PathBuf, String> {
+    let canonical = cwd.canonicalize().map_err(|e| {
+        format!(
+            "Cannot resolve Bash working directory '{}': {e}",
+            cwd.display()
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err(format!(
+            "Bash working directory '{}' is not a directory",
+            canonical.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+#[cfg(target_os = "linux")]
+fn find_bwrap() -> Result<PathBuf, String> {
+    const TRUSTED_LOCATIONS: &[&str] = &[
+        "/usr/bin/bwrap",
+        "/usr/sbin/bwrap",
+        "/bin/bwrap",
+        "/sbin/bwrap",
+    ];
+    for candidate in TRUSTED_LOCATIONS {
+        let path = Path::new(candidate);
+        if path.is_file() {
+            let resolved = path
+                .canonicalize()
+                .map_err(|e| format!("Cannot resolve bubblewrap at '{candidate}': {e}"))?;
+            let metadata = fs::metadata(&resolved).map_err(|e| {
+                format!("Cannot inspect bubblewrap at '{}': {e}", resolved.display())
+            })?;
+            if metadata.uid() != 0 || metadata.permissions().mode() & 0o022 != 0 {
+                return Err(format!(
+                    "Agent execution is blocked because bubblewrap at '{}' is not root-owned \
+                     and non-writable by group/other",
+                    resolved.display()
+                ));
+            }
+            probe_bwrap(&resolved)?;
+            return Ok(resolved);
+        }
+    }
+    Err(format!(
+        "Bash execution is blocked because bubblewrap (bwrap) is not installed. \
+         Install bubblewrap, or have the host user explicitly accept unsandboxed \
+         execution with {DISABLE_ENV}=off"
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn probe_bwrap(bwrap: &Path) -> Result<(), String> {
+    let true_bin = ["/usr/bin/true", "/bin/true"]
+        .iter()
+        .map(Path::new)
+        .find(|path| path.is_file())
+        .ok_or_else(|| {
+            "Agent execution is blocked because no trusted `true` binary is available for the sandbox health check"
+                .to_string()
+        })?;
+    let root = Arc::new(
+        std::fs::File::open("/")
+            .map_err(|error| format!("Cannot pin root for Bubblewrap probe: {error}"))?,
+    );
+    let root_fd = root.as_raw_fd();
+    let root_for_child = Arc::clone(&root);
+    let mut command = Command::new(bwrap);
+    command
+        .args([
+            "--die-with-parent",
+            "--new-session",
+            "--unshare-all",
+            "--unshare-user",
+            "--disable-userns",
+            "--assert-userns-disabled",
+            "--cap-drop",
+            "ALL",
+            "--ro-bind-fd",
+        ])
+        .arg(root_fd.to_string())
+        .args(["/", "--proc", "/proc", "--dev", "/dev", "--"])
+        .arg(true_bin)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    // SAFETY: fcntl is async-signal-safe and `root_for_child` pins the
+    // descriptor until spawn completes.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fcntl(root_for_child.as_raw_fd(), libc::F_SETFD, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    let output = command.output().map_err(|error| {
+        format!(
+            "Agent execution is blocked because bubblewrap health check could not start: {error}"
+        )
+    })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let diagnostic = crate::tools::safe_truncate(stderr.trim(), 2048);
+    let category = classify_bwrap_probe_failure(diagnostic);
+    Err(format!(
+        "Agent execution is blocked because bubblewrap is installed but unusable \
+         ({category}, status {}): {diagnostic}",
+        output.status,
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn classify_bwrap_probe_failure(stderr: &str) -> &'static str {
+    let lower = stderr.to_ascii_lowercase();
+    if lower.contains("user namespace") || lower.contains("userns") {
+        "user namespaces disabled or restricted"
+    } else if lower.contains("operation not permitted") || lower.contains("permission denied") {
+        "container or kernel namespace policy denied the probe"
+    } else if lower.contains("mount") {
+        "required mount behavior unavailable"
+    } else if lower.contains("setuid") {
+        "setuid bubblewrap configuration rejected"
+    } else {
+        "backend health probe failed"
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn validate_writable_project_tree(root: &Path) -> Result<(), String> {
+    validate_no_nested_mounts(root)?;
+    let root_device = fs::metadata(root)
+        .map_err(|error| format!("Cannot inspect project root '{}': {error}", root.display()))?
+        .dev();
+    let mut stack = vec![root.to_path_buf()];
+    let mut visited = 0usize;
+    let mut hardlinks: HashMap<(u64, u64), (PathBuf, u64, u64)> = HashMap::new();
+
+    while let Some(directory) = stack.pop() {
+        let entries = fs::read_dir(&directory).map_err(|error| {
+            format!(
+                "Cannot securely inspect writable project directory '{}': {error}",
+                directory.display()
+            )
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "Cannot securely inspect an entry below '{}': {error}",
+                    directory.display()
+                )
+            })?;
+            visited = visited.saturating_add(1);
+            if visited > MAX_PROJECT_SCAN_ENTRIES {
+                return Err(format!(
+                    "Refusing to mount project '{}' writable because its security scan exceeded \
+                     {MAX_PROJECT_SCAN_ENTRIES} entries",
+                    root.display()
+                ));
+            }
+
+            let path = entry.path();
+            let relative = path.strip_prefix(root).map_err(|error| {
+                format!(
+                    "Project security scan produced an out-of-root path '{}': {error}",
+                    path.display()
+                )
+            })?;
+            if relative
+                .components()
+                .next()
+                .and_then(|component| component.as_os_str().to_str())
+                .is_some_and(|name| matches!(name, ".git" | ".openclaudia" | ".claude"))
+            {
+                continue;
+            }
+
+            let metadata = fs::symlink_metadata(&path).map_err(|error| {
+                format!(
+                    "Cannot securely inspect project entry '{}': {error}",
+                    path.display()
+                )
+            })?;
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                continue;
+            }
+            if metadata.dev() != root_device {
+                return Err(format!(
+                    "Refusing writable project mount: '{}' crosses onto another filesystem or mount",
+                    path.display()
+                ));
+            }
+            if file_type.is_socket()
+                || file_type.is_fifo()
+                || file_type.is_block_device()
+                || file_type.is_char_device()
+            {
+                return Err(format!(
+                    "Refusing writable project mount because '{}' is a socket, FIFO, or device node",
+                    path.display()
+                ));
+            }
+            if file_type.is_file() && metadata.nlink() > 1 {
+                let record = hardlinks
+                    .entry((metadata.dev(), metadata.ino()))
+                    .or_insert_with(|| (path.clone(), metadata.nlink(), 0));
+                record.2 = record.2.saturating_add(1);
+            }
+            if file_type.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    for (_, (path, link_count, observed_inside_root)) in hardlinks {
+        if observed_inside_root != link_count {
+            return Err(format!(
+                "Refusing writable project mount because '{}' has {link_count} hardlinks but \
+                 only {observed_inside_root} are inside the writable grant; another link may \
+                 alias a file outside the sandbox",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn validate_no_nested_mounts(root: &Path) -> Result<(), String> {
+    let mountinfo = fs::read_to_string("/proc/self/mountinfo")
+        .map_err(|error| format!("Cannot inspect Linux mount table: {error}"))?;
+    for line in mountinfo.lines() {
+        let Some(encoded_mountpoint) = line.split_whitespace().nth(4) else {
+            return Err(
+                "Malformed /proc/self/mountinfo entry; refusing writable mount".to_string(),
+            );
+        };
+        let mountpoint = PathBuf::from(decode_mountinfo_path(encoded_mountpoint)?);
+        if mountpoint != root && mountpoint.starts_with(root) {
+            return Err(format!(
+                "Refusing writable project mount because nested host mount '{}' is inside '{}'",
+                mountpoint.display(),
+                root.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn decode_mountinfo_path(encoded: &str) -> Result<String, String> {
+    let bytes = encoded.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            if index + 3 >= bytes.len()
+                || !bytes[index + 1..=index + 3].iter().all(u8::is_ascii_digit)
+            {
+                return Err(format!(
+                    "Malformed escaped mount path in /proc/self/mountinfo: {encoded}"
+                ));
+            }
+            let octal = &encoded[index + 1..=index + 3];
+            let value = u8::from_str_radix(octal, 8)
+                .map_err(|error| format!("Malformed mount path escape '\\{octal}': {error}"))?;
+            decoded.push(value);
+            index += 4;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded)
+        .map_err(|error| format!("Non-UTF-8 mount path is not supported safely: {error}"))
+}
+
+#[cfg(target_os = "linux")]
+fn install_linux_process_hardening(
+    command: &mut Command,
+    inherited_bind_fds: Vec<OwnedFd>,
+) -> Result<(), String> {
+    let filter = Arc::new(linux_seccomp_filter()?);
+    let process_limit = host_uid_process_limit()?;
+    let inherited_bind_fds = Arc::new(inherited_bind_fds);
+    let preserved_fds: Vec<libc::c_int> = inherited_bind_fds
+        .iter()
+        .map(std::os::fd::AsRawFd::as_raw_fd)
+        .chain(std::iter::once(SECCOMP_FILTER_FD))
+        .collect();
+    // SAFETY: the closure only invokes async-signal-safe libc syscalls between
+    // fork and exec. It performs no allocation, locking, or environment access.
+    unsafe {
+        command.pre_exec(move || {
+            apply_sandbox_rlimits(Some(process_limit))?;
+            for fd in inherited_bind_fds.iter() {
+                if libc::fcntl(fd.as_raw_fd(), libc::F_SETFD, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            install_seccomp_filter_fd(&filter)?;
+            close_inherited_file_descriptors(&preserved_fds)
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn close_inherited_file_descriptors(preserved: &[libc::c_int]) -> std::io::Result<()> {
+    const CLOSE_RANGE_LAST: libc::c_uint = libc::c_uint::MAX;
+    // Keep only stdio and descriptors explicitly consumed by Bubblewrap.
+    // `close_range` is required; an unavailable syscall fails spawn closed
+    // instead of preserving ambient host handles.
+    let mut preserved: Vec<u32> = preserved
+        .iter()
+        .filter_map(|fd| u32::try_from(*fd).ok())
+        .filter(|fd| *fd >= 3)
+        .collect();
+    preserved.sort_unstable();
+    preserved.dedup();
+    let mut ranges = Vec::with_capacity(preserved.len() + 1);
+    let mut first = 3u32;
+    for fd in preserved {
+        if first < fd {
+            ranges.push((first, fd - 1));
+        }
+        first = fd.saturating_add(1);
+    }
+    ranges.push((first, CLOSE_RANGE_LAST));
+    for (first, last) in ranges {
+        let result = unsafe { libc::syscall(libc::SYS_close_range, first, last, 0u32) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn apply_sandbox_rlimits(process_limit: Option<libc::rlim_t>) -> std::io::Result<()> {
+    set_rlimit(libc::RLIMIT_CORE, 0)?;
+    set_rlimit(libc::RLIMIT_NOFILE, 1024)?;
+    set_rlimit(libc::RLIMIT_FSIZE, 256 * 1024 * 1024)?;
+    set_rlimit(libc::RLIMIT_CPU, 300)?;
+    set_rlimit(libc::RLIMIT_AS, 4 * 1024 * 1024 * 1024)?;
+    if let Some(limit) = process_limit {
+        set_rlimit(libc::RLIMIT_NPROC, limit)?;
+    }
+    Ok(())
+}
+
+/// `RLIMIT_NPROC` is per real host UID rather than per PID namespace. A fixed
+/// value can prevent Bubblewrap itself from cloning when the desktop account
+/// already owns many processes. Pin the observed baseline and allow at most
+/// 256 additional processes across the command lifetime. cgroup-v2 remains
+/// preferable when the service manager delegates a writable subtree, while
+/// this conservative fallback works in ordinary unprivileged shells.
+#[cfg(target_os = "linux")]
+fn host_uid_process_limit() -> Result<libc::rlim_t, String> {
+    let uid = unsafe { libc::geteuid() };
+    let entries = fs::read_dir("/proc")
+        .map_err(|error| format!("Cannot inspect process count for sandbox limits: {error}"))?;
+    let mut count = 0u64;
+    for entry in entries.flatten() {
+        if !entry
+            .file_name()
+            .to_string_lossy()
+            .bytes()
+            .all(|byte| byte.is_ascii_digit())
+        {
+            continue;
+        }
+        if entry.metadata().is_ok_and(|metadata| metadata.uid() == uid) {
+            // Linux accounts threads, not merely thread-group leaders,
+            // against RLIMIT_NPROC.
+            let task_count = fs::read_dir(entry.path().join("task"))
+                .map_or(1, |tasks| u64::try_from(tasks.count()).unwrap_or(u64::MAX));
+            count = count.saturating_add(task_count);
+        }
+    }
+    Ok(count.saturating_add(256))
+}
+
+#[cfg(target_os = "linux")]
+fn set_rlimit(resource: libc::__rlimit_resource_t, value: libc::rlim_t) -> std::io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: value,
+        rlim_max: value,
+    };
+    // SAFETY: `limit` points to an initialized `rlimit`, and `resource` is
+    // one of the platform constants supplied by the callers above.
+    if unsafe { libc::setrlimit(resource, &raw const limit) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn install_seccomp_filter_fd(filter: &[u8]) -> std::io::Result<()> {
+    let mut pipe_fds = [0; 2];
+    // SAFETY: `pipe_fds` points to two writable integers.
+    if unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let read_fd = pipe_fds[0];
+    let write_fd = pipe_fds[1];
+    let mut written = 0usize;
+    while written < filter.len() {
+        // SAFETY: the slice pointer is valid for the remaining byte count and
+        // `write_fd` is the pipe endpoint created above.
+        let result = unsafe {
+            libc::write(
+                write_fd,
+                filter[written..].as_ptr().cast(),
+                filter.len() - written,
+            )
+        };
+        if result < 0 {
+            let error = std::io::Error::last_os_error();
+            // SAFETY: both descriptors were returned by `pipe`.
+            unsafe {
+                libc::close(read_fd);
+                libc::close(write_fd);
+            }
+            return Err(error);
+        }
+        if result == 0 {
+            unsafe {
+                libc::close(read_fd);
+                libc::close(write_fd);
+            }
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "seccomp filter pipe accepted zero bytes",
+            ));
+        }
+        written += usize::try_from(result)
+            .map_err(|_| std::io::Error::other("seccomp write count overflow"))?;
+    }
+    // SAFETY: write endpoint is no longer needed after the complete filter has
+    // been buffered.
+    unsafe {
+        libc::close(write_fd);
+    }
+    if read_fd != SECCOMP_FILTER_FD {
+        // SAFETY: duplicate the valid read endpoint onto the fixed descriptor
+        // named in Bubblewrap's `--seccomp` argument.
+        if unsafe { libc::dup2(read_fd, SECCOMP_FILTER_FD) } < 0 {
+            let error = std::io::Error::last_os_error();
+            // SAFETY: `read_fd` remains owned by this closure on failure.
+            unsafe {
+                libc::close(read_fd);
+            }
+            return Err(error);
+        }
+        // SAFETY: the duplicated descriptor now owns the same open file.
+        unsafe {
+            libc::close(read_fd);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn linux_seccomp_filter() -> Result<Vec<u8>, String> {
+    #[cfg(target_arch = "x86_64")]
+    const AUDIT_ARCH: u32 = 0xc000_003e;
+    #[cfg(target_arch = "aarch64")]
+    const AUDIT_ARCH: u32 = 0xc000_00b7;
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        return Err(format!(
+            "Agent execution is blocked: no seccomp policy is defined for Linux architecture {}",
+            std::env::consts::ARCH
+        ));
+    }
+
+    const BPF_LD_W_ABS: u16 = 0x20;
+    const BPF_JMP_JEQ_K: u16 = 0x15;
+    const BPF_RET_K: u16 = 0x06;
+    const SECCOMP_RET_KILL_PROCESS: u32 = 0x8000_0000;
+    const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
+    const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+
+    let statement = |code, value| libc::sock_filter {
+        code,
+        jt: 0,
+        jf: 0,
+        k: value,
+    };
+    let jump = |value, jt, jf| libc::sock_filter {
+        code: BPF_JMP_JEQ_K,
+        jt,
+        jf,
+        k: value,
+    };
+    let mut program = vec![
+        statement(BPF_LD_W_ABS, 4),
+        jump(AUDIT_ARCH, 1, 0),
+        statement(BPF_RET_K, SECCOMP_RET_KILL_PROCESS),
+        statement(BPF_LD_W_ABS, 0),
+    ];
+    for syscall in denied_linux_syscalls() {
+        program.push(jump(syscall, 0, 1));
+        program.push(statement(
+            BPF_RET_K,
+            SECCOMP_RET_ERRNO | u32::try_from(libc::EPERM).unwrap_or(1),
+        ));
+    }
+    program.push(statement(BPF_RET_K, SECCOMP_RET_ALLOW));
+
+    let byte_len = program
+        .len()
+        .checked_mul(std::mem::size_of::<libc::sock_filter>())
+        .ok_or_else(|| "seccomp filter size overflow".to_string())?;
+    // SAFETY: `program` is alive for the copy, and `byte_len` exactly spans
+    // its contiguous initialized `sock_filter` elements.
+    let bytes =
+        unsafe { std::slice::from_raw_parts(program.as_ptr().cast::<u8>(), byte_len) }.to_vec();
+    Ok(bytes)
+}
+
+#[cfg(target_os = "linux")]
+fn denied_linux_syscalls() -> Vec<u32> {
+    [
+        libc::SYS_mount,
+        libc::SYS_umount2,
+        libc::SYS_pivot_root,
+        libc::SYS_ptrace,
+        libc::SYS_bpf,
+        libc::SYS_perf_event_open,
+        libc::SYS_keyctl,
+        libc::SYS_add_key,
+        libc::SYS_request_key,
+        libc::SYS_init_module,
+        libc::SYS_finit_module,
+        libc::SYS_delete_module,
+        libc::SYS_kexec_load,
+        libc::SYS_userfaultfd,
+        libc::SYS_unshare,
+        libc::SYS_setns,
+        libc::SYS_open_by_handle_at,
+        libc::SYS_name_to_handle_at,
+        libc::SYS_process_vm_readv,
+        libc::SYS_process_vm_writev,
+        libc::SYS_io_uring_setup,
+        libc::SYS_socket,
+        libc::SYS_socketpair,
+        libc::SYS_connect,
+        libc::SYS_bind,
+        libc::SYS_listen,
+        libc::SYS_accept,
+        libc::SYS_accept4,
+        libc::SYS_sendto,
+        libc::SYS_sendmsg,
+        libc::SYS_sendmmsg,
+        libc::SYS_reboot,
+        libc::SYS_swapon,
+        libc::SYS_swapoff,
+    ]
+    .into_iter()
+    .filter_map(|syscall| u32::try_from(syscall).ok())
+    .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn add_read_only_tree_if_present(cmd: &mut Command, path: &Path) {
+    if path.exists() {
+        cmd.arg("--ro-bind").arg(path).arg(path);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn add_runtime_alias(cmd: &mut Command, destination: &str, target: &str) {
+    let destination_path = Path::new(destination);
+    if let Ok(link_target) = std::fs::read_link(destination_path) {
+        cmd.arg("--symlink").arg(link_target).arg(destination_path);
+    } else if destination_path.exists() {
+        add_read_only_tree_if_present(cmd, destination_path);
+    } else if Path::new("/usr")
+        .join(target.trim_start_matches("usr/"))
+        .exists()
+    {
+        cmd.args(["--symlink", target, destination]);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn add_directory_ancestors(cmd: &mut Command, made_dirs: &mut HashSet<PathBuf>, path: &Path) {
+    let mut ancestors: Vec<_> = path.ancestors().collect();
+    ancestors.reverse();
+    for ancestor in ancestors {
+        if ancestor != Path::new("/") {
+            add_directory(cmd, made_dirs, ancestor);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn add_directory(cmd: &mut Command, made_dirs: &mut HashSet<PathBuf>, path: &Path) {
+    if made_dirs.insert(path.to_path_buf()) {
+        cmd.arg("--dir").arg(path);
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_lines)]
+fn protect_repository_metadata(
+    cmd: &mut Command,
+    made_dirs: &mut HashSet<PathBuf>,
+    inherited_bind_fds: &mut Vec<OwnedFd>,
+    project_root: &Path,
+) -> Result<(), String> {
+    let path = project_root.join(".git");
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "Cannot inspect repository metadata boundary: {error}"
+            ))
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return Err("Refusing a symbolic-link .git metadata entry".to_string());
+    }
+    if metadata.is_dir() {
+        // Present a minimal read-only Git database instead of the whole
+        // directory. This keeps status/diff functional without exposing
+        // credential-bearing remote URLs, hooks, reflogs, or mutable locks.
+        cmd.arg("--tmpfs").arg(&path);
+        for entry in ["HEAD", "index", "objects", "refs", "packed-refs", "shallow"] {
+            let source = path.join(entry);
+            if source.exists() {
+                add_pinned_read_only_bind(cmd, inherited_bind_fds, &source)?;
+            }
+        }
+        cmd.args(["--chmod", "0555"]).arg(&path);
+        return Ok(());
+    }
+    if !metadata.is_file() {
+        return Err("Refusing non-file, non-directory .git metadata entry".to_string());
+    }
+
+    let contents = fs::read_to_string(&path)
+        .map_err(|error| format!("Cannot read linked-worktree .git file: {error}"))?;
+    if contents.len() > 4096 {
+        return Err("Refusing oversized linked-worktree .git file".to_string());
+    }
+    let target = contents
+        .trim()
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .filter(|target| !target.is_empty())
+        .ok_or_else(|| "Refusing malformed linked-worktree .git file".to_string())?;
+    let target = Path::new(target);
+    let admin_candidate = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        project_root.join(target)
+    };
+    let admin = admin_candidate
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve linked-worktree metadata: {error}"))?;
+    if !admin.is_dir() {
+        return Err("Linked-worktree metadata target is not a directory".to_string());
+    }
+    let commondir_text = fs::read_to_string(admin.join("commondir"))
+        .map_err(|error| format!("Linked-worktree metadata has no valid commondir: {error}"))?;
+    let commondir_rel = Path::new(commondir_text.trim());
+    if commondir_rel.as_os_str().is_empty() {
+        return Err("Linked-worktree commondir is empty".to_string());
+    }
+    let common_candidate = if commondir_rel.is_absolute() {
+        commondir_rel.to_path_buf()
+    } else {
+        admin.join(commondir_rel)
+    };
+    let common = common_candidate
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve linked-worktree common metadata: {error}"))?;
+    let expected_admin_parent = common.join("worktrees").canonicalize().map_err(|error| {
+        format!("Linked-worktree common metadata has no worktrees directory: {error}")
+    })?;
+    if admin.parent() != Some(expected_admin_parent.as_path()) {
+        return Err(
+            "Refusing linked-worktree metadata that is not owned by its declared common repository"
+                .to_string(),
+        );
+    }
+    let backlink = fs::read_to_string(admin.join("gitdir"))
+        .map_err(|error| format!("Linked-worktree metadata has no backlink: {error}"))?;
+    let backlink = Path::new(backlink.trim())
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve linked-worktree backlink: {error}"))?;
+    let expected_backlink = path
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve worktree .git backlink target: {error}"))?;
+    if backlink != expected_backlink {
+        return Err(
+            "Refusing linked-worktree metadata whose backlink does not name this worktree"
+                .to_string(),
+        );
+    }
+
+    // The indirection file is harmless after the target and backlink have
+    // been proven. Construct empty metadata directories at their original
+    // absolute locations, then expose only object/ref/index state. Config,
+    // hooks, credentials, logs/reflogs, and sibling worktrees stay absent.
+    add_pinned_read_only_bind(cmd, inherited_bind_fds, &path)?;
+    for directory in [&common, &expected_admin_parent, &admin] {
+        add_directory_ancestors(cmd, made_dirs, directory);
+    }
+    for entry in ["HEAD", "index", "commondir", "gitdir"] {
+        let source = admin.join(entry);
+        if source.exists() {
+            add_pinned_read_only_bind(cmd, inherited_bind_fds, &source)?;
+        }
+    }
+    for entry in ["HEAD", "objects", "refs", "packed-refs", "shallow"] {
+        let source = common.join(entry);
+        if source.exists() {
+            add_pinned_read_only_bind(cmd, inherited_bind_fds, &source)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn add_pinned_read_only_bind(
+    cmd: &mut Command,
+    inherited_bind_fds: &mut Vec<OwnedFd>,
+    source: &Path,
+) -> Result<(), String> {
+    let source_c = std::ffi::CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| format!("Git metadata path contains NUL: '{}'", source.display()))?;
+    let opened = unsafe {
+        libc::open(
+            source_c.as_ptr(),
+            libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if opened < 0 {
+        return Err(format!(
+            "Cannot pin Git metadata '{}': {}",
+            source.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: open returned a fresh descriptor.
+    let opened = unsafe { OwnedFd::from_raw_fd(opened) };
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(opened.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(format!(
+            "Cannot inspect pinned Git metadata '{}': {}",
+            source.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: fstat initialized `stat` on success.
+    let stat = unsafe { stat.assume_init() };
+    let kind = stat.st_mode & libc::S_IFMT;
+    if kind != libc::S_IFREG && kind != libc::S_IFDIR {
+        return Err(format!(
+            "Refusing non-regular, non-directory Git metadata '{}'",
+            source.display()
+        ));
+    }
+    if kind == libc::S_IFREG && stat.st_nlink > 1 {
+        return Err(format!(
+            "Refusing hardlinked Git metadata '{}'; another name may be outside the session capability",
+            source.display()
+        ));
+    }
+    let duplicated = unsafe { libc::fcntl(opened.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 200) };
+    if duplicated < 0 {
+        return Err(format!(
+            "Cannot duplicate Git metadata handle '{}': {}",
+            source.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: fcntl returned a fresh owned descriptor.
+    let pinned = unsafe { OwnedFd::from_raw_fd(duplicated) };
+    cmd.arg("--ro-bind-fd")
+        .arg(pinned.as_raw_fd().to_string())
+        .arg(source);
+    inherited_bind_fds.push(pinned);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn hide_control_path(cmd: &mut Command, path: &Path) {
+    if path.is_dir() {
+        cmd.arg("--tmpfs").arg(path);
+    } else if path.exists() {
+        cmd.arg("--ro-bind").arg("/dev/null").arg(path);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sandbox_path(cwd: &Path, home: Option<&Path>, permit_project_path: bool) -> String {
+    let mut allowed = Vec::new();
+    let cargo_bin = home.map(|path| path.join(".cargo/bin"));
+    for entry in std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()) {
+        let is_allowed = entry.starts_with("/usr")
+            || entry.starts_with("/bin")
+            || entry.starts_with("/sbin")
+            || entry.starts_with("/nix/store")
+            || (permit_project_path && entry.starts_with(cwd))
+            || cargo_bin
+                .as_ref()
+                .is_some_and(|path| entry.starts_with(path));
+        if is_allowed && !allowed.contains(&entry) {
+            allowed.push(entry);
+        }
+    }
+    if allowed.is_empty() {
+        allowed.extend([
+            PathBuf::from("/usr/local/bin"),
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/bin"),
+        ]);
+    }
+    std::env::join_paths(allowed)
+        .unwrap_or_else(|_| std::ffi::OsString::from("/usr/local/bin:/usr/bin:/bin"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn sandbox_path_does_not_include_arbitrary_home_directories() {
+        let cwd = Path::new("/home/user/project");
+        let home = Path::new("/home/user");
+        let path = sandbox_path(cwd, Some(home), true);
+        assert!(!path
+            .split(':')
+            .any(|entry| entry == "/home/user/private/bin"));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn broad_system_roots_are_never_writable_project_mounts() {
+        for root in ["/", "/etc", "/home", "/mnt", "/tmp", "/usr", "/var"] {
+            assert!(is_unsafe_broad_project_root(Path::new(root)), "{root}");
+        }
+        for project in ["/app", "/tmp/project", "/mnt/c/project", "/var/src/project"] {
+            assert!(
+                !is_unsafe_broad_project_root(Path::new(project)),
+                "{project}"
+            );
+        }
+    }
+
+    #[test]
+    fn mode_parser_only_accepts_explicit_values() {
+        for enabled in ["", "on", "1", "true", "required", "ON"] {
+            assert_eq!(sandbox_explicitly_disabled_value(enabled), Ok(false));
+        }
+        for disabled in ["off", "0", "false", "disabled", "OFF"] {
+            assert_eq!(sandbox_explicitly_disabled_value(disabled), Ok(true));
+        }
+        for invalid in ["maybe", "auto-ish", "please"] {
+            assert!(sandbox_explicitly_disabled_value(invalid).is_err());
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn health_probe_failures_are_classified() {
+        assert_eq!(
+            classify_bwrap_probe_failure("No permissions to create new user namespace"),
+            "user namespaces disabled or restricted"
+        );
+        assert_eq!(
+            classify_bwrap_probe_failure("Creating new namespace failed: Operation not permitted"),
+            "container or kernel namespace policy denied the probe"
+        );
+        assert_eq!(
+            classify_bwrap_probe_failure("mount source failed"),
+            "required mount behavior unavailable"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn capability_roots_are_handed_to_bubblewrap_by_descriptor() {
+        let security = crate::tools::security::current_context().expect("security context");
+        let command = sandboxed_process_command(
+            SandboxProfile::Shell,
+            std::ffi::OsStr::new("/usr/bin/true"),
+            &[],
+            security.working_directory(),
+        )
+        .expect("sandbox command");
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert!(args.iter().any(|arg| arg == "--bind-fd"));
+        assert!(!args.windows(2).any(|pair| {
+            pair[0] == "--bind" && pair[1] == security.project_root().to_string_lossy()
+        }));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linked_worktree_metadata_is_validated_and_minimized() {
+        let fixture = tempfile::tempdir().expect("linked-worktree fixture");
+        let common = fixture.path().join("main.git");
+        let worktree = fixture.path().join("worktree");
+        let admin = common.join("worktrees").join("agent");
+        std::fs::create_dir_all(common.join("objects")).expect("objects");
+        std::fs::create_dir_all(common.join("refs")).expect("refs");
+        std::fs::create_dir_all(&admin).expect("admin");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        std::fs::write(common.join("HEAD"), "ref: refs/heads/main\n").expect("common HEAD");
+        std::fs::write(common.join("config"), "credential.helper=escape\n").expect("config");
+        std::fs::create_dir_all(common.join("hooks")).expect("hooks");
+        std::fs::write(admin.join("HEAD"), "ref: refs/heads/agent\n").expect("admin HEAD");
+        std::fs::write(admin.join("index"), "").expect("index");
+        std::fs::write(admin.join("commondir"), "../..\n").expect("commondir");
+        std::fs::write(
+            admin.join("gitdir"),
+            format!("{}\n", worktree.join(".git").display()),
+        )
+        .expect("backlink");
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", admin.display()),
+        )
+        .expect("indirection");
+
+        let mut command = Command::new("/usr/bin/true");
+        let mut made_dirs = HashSet::new();
+        let mut inherited_bind_fds = Vec::new();
+        protect_repository_metadata(
+            &mut command,
+            &mut made_dirs,
+            &mut inherited_bind_fds,
+            &worktree,
+        )
+        .expect("valid linked worktree");
+        let args: Vec<_> = command.get_args().map(PathBuf::from).collect();
+        assert!(args.contains(&common.join("objects")));
+        assert!(args.contains(&common.join("refs")));
+        assert!(!args.contains(&common.join("config")));
+        assert!(!args.contains(&common.join("hooks")));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn forged_linked_worktree_indirection_is_rejected() {
+        let fixture = tempfile::tempdir().expect("forged worktree fixture");
+        let worktree = fixture.path().join("worktree");
+        let arbitrary = fixture.path().join("arbitrary-host-directory");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        std::fs::create_dir_all(&arbitrary).expect("arbitrary");
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", arbitrary.display()),
+        )
+        .expect("forged indirection");
+
+        let mut command = Command::new("/usr/bin/true");
+        let mut made_dirs = HashSet::new();
+        let mut inherited_bind_fds = Vec::new();
+        let error = protect_repository_metadata(
+            &mut command,
+            &mut made_dirs,
+            &mut inherited_bind_fds,
+            &worktree,
+        )
+        .expect_err("arbitrary metadata target must be rejected");
+        assert!(error.contains("commondir") || error.contains("owned"));
+    }
+}

--- a/src/tools/command.rs
+++ b/src/tools/command.rs
@@ -16,17 +16,120 @@
 //! backoff matches the schedule worktree.rs already used so trivial
 //! commands still see sub-millisecond exit-detection overhead.
 
-use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::io::Write as _;
+use std::collections::{HashMap, HashSet};
+use std::ffi::{OsStr, OsString};
+use std::io::{Read, Write as _};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 /// Exponential-backoff polling schedule (ms between `try_wait` calls).
 /// Pins on the last entry once exhausted so long-running commands cost
 /// at most one poll per 100 ms (crosslink #956, #836).
 const WAIT_BACKOFF_MS: &[u64] = &[1, 2, 5, 10, 25, 50, 100];
+const MAX_CAPTURE_BYTES_PER_STREAM: usize = 10 * 1024 * 1024;
+const OUTPUT_TRUNCATED_MARKER: &[u8] = b"\n[output truncated at 10 MiB]\n";
+
+static ACTIVE_SANDBOX_PROCESSES: LazyLock<Mutex<HashMap<String, HashSet<u32>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static CANCELLED_SANDBOX_SESSIONS: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+pub struct ActiveSandboxProcess {
+    owner: String,
+    pid: u32,
+}
+
+impl ActiveSandboxProcess {
+    pub(crate) fn register(pid: u32) -> Self {
+        let owner = crate::tools::todo::current_session_key();
+        let mut active = ACTIVE_SANDBOX_PROCESSES
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        active.entry(owner.clone()).or_default().insert(pid);
+        tracing::debug!(
+            target: "openclaudia::sandbox",
+            event = "sandbox_process_started",
+            session_id = owner,
+            pid,
+            "Registered cancellable sandbox process"
+        );
+        drop(active);
+        let cancelled = CANCELLED_SANDBOX_SESSIONS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(&owner);
+        if cancelled {
+            crate::tools::bash::terminate_process_tree(pid);
+        }
+        Self { owner, pid }
+    }
+}
+
+impl Drop for ActiveSandboxProcess {
+    fn drop(&mut self) {
+        let mut active = ACTIVE_SANDBOX_PROCESSES
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(processes) = active.get_mut(&self.owner) {
+            processes.remove(&self.pid);
+            if processes.is_empty() {
+                active.remove(&self.owner);
+            }
+        }
+    }
+}
+
+/// Terminate every synchronous sandbox process currently owned by a session.
+pub fn cancel_session_sandbox_processes(session_id: &str) -> usize {
+    CANCELLED_SANDBOX_SESSIONS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(session_id.to_string());
+    let pids: Vec<u32> = ACTIVE_SANDBOX_PROCESSES
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(session_id)
+        .map(|pids| pids.iter().copied().collect())
+        .unwrap_or_default();
+    for pid in &pids {
+        crate::tools::bash::terminate_process_tree(*pid);
+    }
+    if !pids.is_empty() {
+        tracing::info!(
+            target: "openclaudia::sandbox",
+            event = "sandbox_processes_cancelled",
+            session_id,
+            count = pids.len(),
+            "Terminated session sandbox processes"
+        );
+    }
+    pids.len()
+}
+
+/// Start a new cancellation generation for a session. ACP calls this exactly
+/// once when accepting a fresh prompt, before any of its tool workers spawn.
+pub fn clear_session_process_cancellation(session_id: &str) {
+    CANCELLED_SANDBOX_SESSIONS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(session_id);
+}
+
+/// ACP runs as a dedicated process. On transport EOF, terminate any remaining
+/// synchronous sandbox work before shutting the server down.
+pub fn cancel_all_sandbox_processes() {
+    let owners: Vec<String> = ACTIVE_SANDBOX_PROCESSES
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .keys()
+        .cloned()
+        .collect();
+    for owner in owners {
+        cancel_session_sandbox_processes(&owner);
+    }
+}
 
 /// Run `program` with `args` under `timeout`. Captures stdout and
 /// stderr (both `Stdio::piped`) and returns them in [`Output`] on a
@@ -47,6 +150,7 @@ const WAIT_BACKOFF_MS: &[u64] = &[1, 2, 5, 10, 25, 50, 100];
 /// Wait errors (a rare kernel-side condition: signal handler races,
 /// EINTR after retry exhaustion) surface as
 /// [`CommandError::WaitFailed`].
+#[cfg(test)]
 pub fn run_with_timeout(
     program: &(impl AsRef<OsStr> + ?Sized),
     args: &[impl AsRef<OsStr>],
@@ -65,6 +169,7 @@ pub fn run_with_timeout(
 ///
 /// Returns the same structured [`CommandError`] variants as
 /// [`run_with_timeout`].
+#[cfg(test)]
 pub fn run_with_timeout_with_env(
     program: &(impl AsRef<OsStr> + ?Sized),
     args: &[impl AsRef<OsStr>],
@@ -72,7 +177,7 @@ pub fn run_with_timeout_with_env(
     timeout: Duration,
     env: &HashMap<String, String>,
 ) -> Result<Output, CommandError> {
-    run_with_timeout_inner(program, args, cwd, timeout, env, None)
+    run_test_host_with_timeout_inner(program, args, cwd, timeout, env, None)
 }
 
 /// Run `program` under `timeout`, writing `stdin_input` to the child before
@@ -87,6 +192,7 @@ pub fn run_with_timeout_with_env(
 /// Returns the same structured [`CommandError`] variants as
 /// [`run_with_timeout`]. A stdin write failure is reported as
 /// [`CommandError::WaitFailed`] after killing and reaping the child.
+#[cfg(test)]
 pub fn run_with_timeout_with_input(
     program: &(impl AsRef<OsStr> + ?Sized),
     args: &[impl AsRef<OsStr>],
@@ -94,7 +200,7 @@ pub fn run_with_timeout_with_input(
     timeout: Duration,
     stdin_input: &[u8],
 ) -> Result<Output, CommandError> {
-    run_with_timeout_inner(
+    run_test_host_with_timeout_inner(
         program,
         args,
         cwd,
@@ -104,7 +210,70 @@ pub fn run_with_timeout_with_input(
     )
 }
 
-fn run_with_timeout_inner(
+/// Sandboxed counterpart to [`run_with_timeout_with_input`].
+///
+/// # Errors
+///
+/// Returns the same structured [`CommandError`] variants as
+/// [`run_sandboxed_with_timeout`].
+pub fn run_sandboxed_with_timeout_with_input(
+    program: &(impl AsRef<OsStr> + ?Sized),
+    args: &[impl AsRef<OsStr>],
+    project_root: &Path,
+    timeout: Duration,
+    stdin_input: &[u8],
+) -> Result<Output, CommandError> {
+    run_sandboxed_with_timeout_inner(
+        crate::tools::SandboxProfile::DocumentParser,
+        program,
+        args,
+        project_root,
+        timeout,
+        &HashMap::new(),
+        Some(stdin_input),
+    )
+}
+
+/// Run a process under a named sandbox profile with explicit environment
+/// grants and no stdin payload.
+pub fn run_sandboxed_with_timeout_with_env(
+    profile: crate::tools::SandboxProfile,
+    program: &(impl AsRef<OsStr> + ?Sized),
+    args: &[impl AsRef<OsStr>],
+    project_root: &Path,
+    timeout: Duration,
+    env: &HashMap<String, String>,
+) -> Result<Output, CommandError> {
+    run_sandboxed_with_timeout_inner(profile, program, args, project_root, timeout, env, None)
+}
+
+fn run_sandboxed_with_timeout_inner(
+    profile: crate::tools::SandboxProfile,
+    program: &(impl AsRef<OsStr> + ?Sized),
+    args: &[impl AsRef<OsStr>],
+    project_root: &Path,
+    timeout: Duration,
+    env: &HashMap<String, String>,
+    stdin_input: Option<&[u8]>,
+) -> Result<Output, CommandError> {
+    let program_str = program.as_ref().to_string_lossy().into_owned();
+    let sandbox_args: Vec<OsString> = args.iter().map(|arg| arg.as_ref().to_os_string()).collect();
+    let mut cmd = crate::tools::sandboxed_process_command(
+        profile,
+        program.as_ref(),
+        &sandbox_args,
+        project_root,
+    )
+    .map_err(|source| CommandError::SpawnFailed {
+        program: program_str.clone(),
+        source,
+    })?;
+    cmd.envs(env);
+    run_prepared_with_timeout(cmd, program_str, timeout, stdin_input, true)
+}
+
+#[cfg(test)]
+fn run_test_host_with_timeout_inner(
     program: &(impl AsRef<OsStr> + ?Sized),
     args: &[impl AsRef<OsStr>],
     cwd: Option<&Path>,
@@ -113,22 +282,43 @@ fn run_with_timeout_inner(
     stdin_input: Option<&[u8]>,
 ) -> Result<Output, CommandError> {
     let program_str = program.as_ref().to_string_lossy().into_owned();
-    let mut cmd = Command::new(program);
-    cmd.args(args.iter().map(AsRef::as_ref))
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    let mut command = Command::new(program);
+    command.args(args.iter().map(AsRef::as_ref)).envs(env);
+    if let Some(dir) = cwd {
+        command.current_dir(dir);
+    }
+    run_prepared_with_timeout(command, program_str, timeout, stdin_input, false)
+}
+
+/// Execute an already sandboxed command with bounded capture and a wall-clock
+/// deadline.
+pub fn run_prepared_sandboxed_with_timeout(
+    command: Command,
+    program_label: &str,
+    timeout: Duration,
+) -> Result<Output, CommandError> {
+    run_prepared_with_timeout(command, program_label.to_string(), timeout, None, true)
+}
+
+fn run_prepared_with_timeout(
+    mut cmd: Command,
+    program_str: String,
+    timeout: Duration,
+    stdin_input: Option<&[u8]>,
+    terminate_tree: bool,
+) -> Result<Output, CommandError> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     if stdin_input.is_some() {
         cmd.stdin(Stdio::piped());
     }
-    cmd.envs(env);
-    if let Some(dir) = cwd {
-        cmd.current_dir(dir);
-    }
-
     let mut child = cmd.spawn().map_err(|e| CommandError::SpawnFailed {
         program: program_str.clone(),
         source: e.to_string(),
     })?;
+    let pid = child.id();
+    let _active_process = terminate_tree.then(|| ActiveSandboxProcess::register(pid));
+    let stdout_reader = child.stdout.take().map(spawn_bounded_reader);
+    let stderr_reader = child.stderr.take().map(spawn_bounded_reader);
 
     if let Some(input) = stdin_input {
         let write_result = child
@@ -147,8 +337,10 @@ fn run_with_timeout_inner(
                     })
             });
         if let Err(err) = write_result {
-            let _ = child.kill();
+            terminate_child(&mut child, pid, terminate_tree);
             let _ = child.wait();
+            let _ = join_bounded_reader(stdout_reader);
+            let _ = join_bounded_reader(stderr_reader);
             return Err(err);
         }
     }
@@ -157,18 +349,31 @@ fn run_with_timeout_inner(
     let mut step = 0usize;
     loop {
         match child.try_wait() {
-            Ok(Some(_)) => {
-                return child
-                    .wait_with_output()
-                    .map_err(|e| CommandError::WaitFailed {
-                        program: program_str,
-                        source: e.to_string(),
-                    });
+            Ok(Some(status)) => {
+                let stdout = join_bounded_reader(stdout_reader).map_err(|source| {
+                    CommandError::WaitFailed {
+                        program: program_str.clone(),
+                        source,
+                    }
+                })?;
+                let stderr = join_bounded_reader(stderr_reader).map_err(|source| {
+                    CommandError::WaitFailed {
+                        program: program_str.clone(),
+                        source,
+                    }
+                })?;
+                return Ok(Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    let _ = child.kill();
+                    terminate_child(&mut child, pid, terminate_tree);
                     let _ = child.wait();
+                    let _ = join_bounded_reader(stdout_reader);
+                    let _ = join_bounded_reader(stderr_reader);
                     return Err(CommandError::TimedOut {
                         program: program_str,
                         timeout,
@@ -179,6 +384,10 @@ fn run_with_timeout_inner(
                 step = step.saturating_add(1);
             }
             Err(e) => {
+                terminate_child(&mut child, pid, terminate_tree);
+                let _ = child.wait();
+                let _ = join_bounded_reader(stdout_reader);
+                let _ = join_bounded_reader(stderr_reader);
                 return Err(CommandError::WaitFailed {
                     program: program_str,
                     source: e.to_string(),
@@ -186,6 +395,52 @@ fn run_with_timeout_inner(
             }
         }
     }
+}
+
+fn terminate_child(child: &mut std::process::Child, pid: u32, terminate_tree: bool) {
+    if terminate_tree {
+        crate::tools::bash::terminate_process_tree(pid);
+    }
+    let _ = child.kill();
+}
+
+fn spawn_bounded_reader<R: Read + Send + 'static>(
+    mut reader: R,
+) -> std::thread::JoinHandle<Result<Vec<u8>, String>> {
+    std::thread::spawn(move || {
+        let mut retained = Vec::new();
+        let mut buffer = [0u8; 8192];
+        let mut truncated = false;
+        loop {
+            let count = reader
+                .read(&mut buffer)
+                .map_err(|error| format!("captured-output read failed: {error}"))?;
+            if count == 0 {
+                break;
+            }
+            let remaining = MAX_CAPTURE_BYTES_PER_STREAM.saturating_sub(retained.len());
+            let keep = count.min(remaining);
+            retained.extend_from_slice(&buffer[..keep]);
+            truncated |= keep < count;
+        }
+        if truncated {
+            retained.extend_from_slice(OUTPUT_TRUNCATED_MARKER);
+        }
+        Ok(retained)
+    })
+}
+
+fn join_bounded_reader(
+    reader: Option<std::thread::JoinHandle<Result<Vec<u8>, String>>>,
+) -> Result<Vec<u8>, String> {
+    reader.map_or_else(
+        || Ok(Vec::new()),
+        |reader| {
+            reader
+                .join()
+                .map_err(|_| "captured-output reader panicked".to_string())?
+        },
+    )
 }
 
 /// Errors returned by [`run_with_timeout`]. The variants are
@@ -305,5 +560,27 @@ mod tests {
         .expect("cat must echo stdin");
         assert!(out.status.success(), "cat exit status must be 0");
         assert_eq!(out.stdout, b"alpha\nbeta\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn captured_output_is_bounded_while_pipe_is_fully_drained() {
+        let out = run_with_timeout(
+            "sh",
+            &["-c", "yes x | head -c 12582912"],
+            None,
+            Duration::from_secs(10),
+        )
+        .expect("output producer must complete without a pipe deadlock");
+        assert!(out.status.success());
+        assert!(
+            out.stdout.len() <= MAX_CAPTURE_BYTES_PER_STREAM + OUTPUT_TRUNCATED_MARKER.len(),
+            "capture exceeded the configured bound: {} bytes",
+            out.stdout.len()
+        );
+        assert!(
+            out.stdout.ends_with(OUTPUT_TRUNCATED_MARKER),
+            "truncated output must carry a bounded diagnostic"
+        );
     }
 }

--- a/src/tools/cron.rs
+++ b/src/tools/cron.rs
@@ -222,14 +222,14 @@ impl ScheduleStore {
 /// back to the original relative path rather than panic — surfacing
 /// a `warn!` so the operator can see what happened.
 fn schedules_path() -> PathBuf {
-    match std::env::current_dir() {
-        Ok(cwd) => cwd.join(SCHEDULES_FILE),
+    match crate::tools::security::current_context() {
+        Ok(context) => context.working_directory().join(SCHEDULES_FILE),
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                "schedules_path: current_dir() failed; falling back to relative {SCHEDULES_FILE}"
+                "schedules_path: session context unavailable; using an invalid fail-closed path"
             );
-            PathBuf::from(SCHEDULES_FILE)
+            PathBuf::from("/__openclaudia_unavailable__/schedules.json")
         }
     }
 }

--- a/src/tools/crosslink.rs
+++ b/src/tools/crosslink.rs
@@ -69,8 +69,9 @@ const LEGACY_CHAINLINK_DIR: &str = ".chainlink";
 /// into the new location so existing project history survives the
 /// chainlink→crosslink migration.
 fn db_path_for_cwd() -> Result<PathBuf, String> {
-    let cwd =
-        std::env::current_dir().map_err(|e| format!("Failed to read current directory: {e}"))?;
+    let cwd = crate::tools::security::current_context()?
+        .working_directory()
+        .to_path_buf();
     let dir = cwd.join(CROSSLINK_DIR);
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create {CROSSLINK_DIR}/: {e}"))?;
     let db = dir.join("issues.db");

--- a/src/tools/file/edit.rs
+++ b/src/tools/file/edit.rs
@@ -1,32 +1,10 @@
-use super::{canonicalize_or_walk_up, resolve_open_path, resolve_path, READ_TRACKER};
+use super::{canonicalize_or_walk_up, resolve_open_path, resolve_path, secure_fs, READ_TRACKER};
 use crate::tools::args::ToolArgs as _;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::Path;
-
-/// Open the file once for read+write with `O_NOFOLLOW` on the leaf so a
-/// symlink-swap between [`resolve_path`]'s canonicalize and this open call
-/// fails with `ELOOP` instead of silently writing through the attacker's
-/// symlink. See crosslink #417 (dup #428).
-#[cfg(unix)]
-fn open_for_edit_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt;
-    std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-}
-
-#[cfg(not(unix))]
-fn open_for_edit_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
-    std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(path)
-}
 
 /// Truncate the open handle to zero and rewrite it with `new_content`.
 /// Keeps `execute_edit_file` under the clippy line budget while preserving
@@ -170,6 +148,7 @@ fn format_edit_success(
 /// when `true` every occurrence of `old_string` is replaced; when `false`
 /// or absent, multi-occurrence inputs are rejected so callers must provide
 /// a uniquely-matching `old_string`.
+#[allow(clippy::too_many_lines)]
 pub fn execute_edit_file(args: &HashMap<String, Value>) -> (String, bool) {
     // crosslink #675: typed accessor.
     let user_path = match args.arg_str_strict("path") {
@@ -245,9 +224,14 @@ pub fn execute_edit_file(args: &HashMap<String, Value>) -> (String, bool) {
 
     // Open ONCE with O_NOFOLLOW against the LEAF-PRESERVING path; all
     // I/O goes through this FD. See crosslink #417 (dup #428).
-    let mut file = match open_for_edit_nofollow(&open_path) {
+    let mut file = match secure_fs::open_regular_edit(&open_path) {
         Ok(f) => f,
-        Err(e) => return (format!("Failed to open file '{path}': {e}"), true),
+        Err(error) => {
+            return (
+                format!("Failed to securely open file '{path}': {error}"),
+                true,
+            )
+        }
     };
 
     let mut content = String::new();
@@ -349,7 +333,7 @@ mod tests {
     /// Write content to a `NamedTempFile`, mark it as read in `READ_TRACKER`,
     /// and return (file, `canonical_path_string`).
     fn tmp_readable(content: &str) -> (NamedTempFile, String) {
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         f.write_all(content.as_bytes()).expect("write");
         let canon = f.path().canonicalize().expect("canonicalize");
         READ_TRACKER.mark_read(&canon);
@@ -638,7 +622,7 @@ mod tests {
     fn edit_requires_prior_read() {
         // Not in #525 spec directly, but the read-before-edit enforcement is a
         // contract that interacts with all Behavior 4/5 tests; pin it explicitly.
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         f.write_all(b"some content\n").expect("write");
         let path = f.path().canonicalize().expect("canon");
         // Deliberately do NOT call READ_TRACKER.mark_read() for this file
@@ -723,7 +707,7 @@ mod tests {
     #[test]
     fn fix417_edit_rejects_symlink_at_target() {
         use tempfile::TempDir;
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let target = dir.path().join("attacker_target.txt");
         std::fs::write(&target, "PROTECTED\n").expect("setup target");
         let leaf = dir.path().join("leaf.txt");

--- a/src/tools/file/glob.rs
+++ b/src/tools/file/glob.rs
@@ -22,12 +22,11 @@
 //!
 //! [`PROJECT_ROOT`]: super::PROJECT_ROOT
 
-use super::resolve_path;
+use super::{resolve_path, secure_fs};
 use crate::tools::args::ToolArgs as _;
 use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Hard cap on returned filenames (parity with CC `GlobTool`).
@@ -86,9 +85,21 @@ pub fn execute_glob(args: &HashMap<String, Value>) -> (String, bool) {
     let mut visited: usize = 0;
     let mut truncated = false;
 
+    let directory = match secure_fs::open_directory(&root) {
+        Ok(directory) => directory,
+        Err(error) => {
+            return (
+                format!(
+                    "Failed to securely open glob root '{}': {error}",
+                    root.display()
+                ),
+                true,
+            );
+        }
+    };
     walk(
-        &root,
-        &root,
+        &directory,
+        Path::new(""),
         &regex,
         allow_hidden_root,
         &mut matches,
@@ -116,8 +127,8 @@ pub fn execute_glob(args: &HashMap<String, Value>) -> (String, bool) {
 }
 
 fn walk(
-    root: &Path,
-    dir: &Path,
+    dir: &secure_fs::SecureDirectory,
+    relative_dir: &Path,
     regex: &Regex,
     allow_hidden_root: bool,
     matches: &mut Vec<String>,
@@ -127,26 +138,19 @@ fn walk(
     if matches.len() >= MAX_RESULTS || *visited >= MAX_WALK_ENTRIES {
         return;
     }
-    let entries = match fs::read_dir(dir) {
+    let entries = match dir.entries() {
         Ok(e) => e,
         Err(e) => {
             tracing::warn!(
-                dir = %dir.display(),
+                dir = %relative_dir.display(),
                 error = %e,
                 "glob: skipping unreadable directory",
             );
             return;
         }
     };
-    let mut subdirs: Vec<PathBuf> = Vec::new();
+    let mut subdirs: Vec<(secure_fs::SecureDirectory, PathBuf)> = Vec::new();
     for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::warn!(error = %e, "glob: skipping unreadable entry");
-                continue;
-            }
-        };
         *visited += 1;
         if *visited >= MAX_WALK_ENTRIES {
             tracing::warn!(
@@ -156,12 +160,9 @@ fn walk(
             *truncated = true;
             return;
         }
-        let path = entry.path();
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if file_type.is_dir() {
-            let name = entry.file_name();
+        let path = relative_dir.join(&entry.name);
+        if entry.kind == secure_fs::SecureFileType::Directory {
+            let name = entry.name;
             let name_str = name.to_string_lossy();
             // Skip hidden / vendor dirs unless caller explicitly chose
             // to descend (root was named such a dir).
@@ -170,12 +171,20 @@ fn walk(
             {
                 continue;
             }
-            subdirs.push(path);
-        } else if file_type.is_file() {
-            let rel = path.strip_prefix(root).unwrap_or(&path);
-            let rel_str = rel.to_string_lossy();
+            match dir.open_child_directory(&name) {
+                Ok(child) => subdirs.push((child, path)),
+                Err(error) => {
+                    tracing::warn!(
+                        entry = %path.display(),
+                        %error,
+                        "glob: directory changed before secure open"
+                    );
+                }
+            }
+        } else if entry.kind == secure_fs::SecureFileType::Regular {
+            let rel_str = path.to_string_lossy();
             if regex.is_match(&rel_str) {
-                matches.push(rel.display().to_string());
+                matches.push(path.display().to_string());
                 if matches.len() >= MAX_RESULTS {
                     *truncated = true;
                     return;
@@ -183,9 +192,9 @@ fn walk(
             }
         }
     }
-    for sub in subdirs {
+    for (sub, relative) in subdirs {
         walk(
-            root, &sub, regex, false, // descend with default hidden-skip behaviour
+            &sub, &relative, regex, false, // descend with default hidden-skip behaviour
             matches, visited, truncated,
         );
         if matches.len() >= MAX_RESULTS || *visited >= MAX_WALK_ENTRIES {
@@ -246,6 +255,7 @@ fn glob_to_regex(pattern: &str) -> Option<Regex> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fs;
     use std::fs::File;
     use std::io::Write as _;
     use tempfile::TempDir;
@@ -264,7 +274,7 @@ mod tests {
     /// Subdirs are reached only with `**`.
     #[test]
     fn glob_matches_rust_files_at_root_with_star() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         write_file(dir.path(), "lib.rs", "fn x() {}");
         write_file(dir.path(), "main.rs", "fn main() {}");
         write_file(dir.path(), "src/inner.rs", "fn y() {}");
@@ -287,7 +297,7 @@ mod tests {
     /// Pin: `**` crosses path separators — `**/*.rs` reaches subdirs.
     #[test]
     fn glob_double_star_crosses_directories() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         write_file(dir.path(), "src/deep/a.rs", "fn a() {}");
         write_file(dir.path(), "src/deep/b.txt", "no");
         let mut args = HashMap::new();
@@ -344,7 +354,7 @@ mod tests {
     /// This pins the "no panic on weird input" invariant.
     #[test]
     fn glob_special_characters_are_escaped_not_panicking() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         // Create a file whose name contains the literal characters we
         // are testing: `[` and `]`. The glob dialect treats these as
         // literals (regex specials are escaped before compile).

--- a/src/tools/file/grep.rs
+++ b/src/tools/file/grep.rs
@@ -17,12 +17,13 @@
 //! `file:line-context` lines for the surrounding window. Capped at
 //! `MAX_MATCHES` so a runaway regex does not flood the agent.
 
-use super::resolve_path;
+use super::{resolve_path, secure_fs};
 use crate::tools::args::ToolArgs as _;
 use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
+use std::fs::File;
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
 /// Hard cap on returned matches before truncation.
@@ -85,65 +86,41 @@ pub fn execute_grep(args: &HashMap<String, Value>) -> (String, bool) {
         Err(e) => return (format!("Invalid regex '{pattern}': {e}"), true),
     };
 
-    // Collect every regular file under `root`, then grep each.
-    let mut files: Vec<PathBuf> = Vec::new();
+    let directory = match secure_fs::open_directory(&root) {
+        Ok(directory) => directory,
+        Err(error) => {
+            return (
+                format!(
+                    "Failed to securely open grep root '{}': {error}",
+                    root.display()
+                ),
+                true,
+            );
+        }
+    };
     let mut visited: usize = 0;
-    collect_files(&root, &mut files, &mut visited);
-
     let mut output: Vec<String> = Vec::new();
     let mut total_matches: usize = 0;
+    let mut files_scanned: usize = 0;
     let mut truncated = false;
-
-    for file in &files {
-        if total_matches >= MAX_MATCHES {
-            truncated = true;
-            break;
-        }
-        let rel = file
-            .strip_prefix(&root)
-            .unwrap_or(file)
-            .display()
-            .to_string();
-        match grep_one(file, &regex, context) {
-            Ok(hits) => {
-                for hit in hits {
-                    if total_matches >= MAX_MATCHES {
-                        truncated = true;
-                        break;
-                    }
-                    for ctx_line in hit.context_before {
-                        output.push(format!("{rel}-{}-{ctx_line}", hit.line_no - 1));
-                    }
-                    output.push(format!("{rel}:{}:{}", hit.line_no, hit.line));
-                    let mut after_no = hit.line_no;
-                    for ctx_line in hit.context_after {
-                        after_no += 1;
-                        output.push(format!("{rel}-{after_no}-{ctx_line}"));
-                    }
-                    if context > 0 {
-                        output.push("--".to_string());
-                    }
-                    total_matches += 1;
-                }
-            }
-            Err(e) => {
-                tracing::warn!(file = %file.display(), error = %e, "grep: file read failed");
-            }
-        }
-    }
+    grep_directory(
+        &directory,
+        Path::new(""),
+        &regex,
+        context,
+        &mut output,
+        &mut total_matches,
+        &mut files_scanned,
+        &mut visited,
+        &mut truncated,
+    );
 
     let header = if truncated {
         format!(
-            "Found {} matches (truncated at {MAX_MATCHES}) across {} files:",
-            total_matches,
-            files.len()
+            "Found {total_matches} matches (truncated at {MAX_MATCHES}) across {files_scanned} files:"
         )
     } else {
-        format!(
-            "Found {} matches across {} files:",
-            total_matches,
-            files.len()
-        )
+        format!("Found {total_matches} matches across {files_scanned} files:")
     };
     let body = output.join("\n");
     let out = if body.is_empty() {
@@ -171,12 +148,16 @@ struct Hit {
     context_after: Vec<String>,
 }
 
-fn grep_one(path: &Path, regex: &Regex, context: usize) -> std::io::Result<Vec<Hit>> {
-    let meta = fs::metadata(path)?;
+fn grep_one(file: File, regex: &Regex, context: usize) -> std::io::Result<Vec<Hit>> {
+    let meta = file.metadata()?;
     if meta.len() > MAX_FILE_BYTES {
         return Ok(Vec::new());
     }
-    let body = fs::read_to_string(path)?;
+    let mut body = String::new();
+    file.take(MAX_FILE_BYTES + 1).read_to_string(&mut body)?;
+    if body.len() > usize::try_from(MAX_FILE_BYTES).unwrap_or(usize::MAX) {
+        return Ok(Vec::new());
+    }
     let lines: Vec<&str> = body.lines().collect();
     let mut hits = Vec::new();
     for (idx, line) in lines.iter().enumerate() {
@@ -210,40 +191,129 @@ fn grep_one(path: &Path, regex: &Regex, context: usize) -> std::io::Result<Vec<H
     Ok(hits)
 }
 
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>, visited: &mut usize) {
-    if *visited >= MAX_WALK_ENTRIES {
+#[allow(clippy::too_many_arguments)]
+fn grep_directory(
+    dir: &secure_fs::SecureDirectory,
+    relative_dir: &Path,
+    regex: &Regex,
+    context: usize,
+    output: &mut Vec<String>,
+    total_matches: &mut usize,
+    files_scanned: &mut usize,
+    visited: &mut usize,
+    truncated: &mut bool,
+) {
+    if *visited >= MAX_WALK_ENTRIES || *total_matches >= MAX_MATCHES {
+        *truncated = true;
         return;
     }
-    let entries = match fs::read_dir(dir) {
+    let entries = match dir.entries() {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!(dir = %dir.display(), error = %e, "grep: skipping unreadable dir");
+            tracing::warn!(
+                dir = %relative_dir.display(),
+                error = %e,
+                "grep: skipping unreadable dir"
+            );
             return;
         }
     };
-    let mut subdirs: Vec<PathBuf> = Vec::new();
+    let mut subdirs: Vec<(secure_fs::SecureDirectory, PathBuf)> = Vec::new();
     for entry in entries {
-        let Ok(entry) = entry else { continue };
         *visited += 1;
         if *visited >= MAX_WALK_ENTRIES {
+            *truncated = true;
             return;
         }
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        let name = entry.file_name();
+        let name = entry.name;
         let name_str = name.to_string_lossy();
-        if file_type.is_dir() {
+        let relative = relative_dir.join(&name);
+        if entry.kind == secure_fs::SecureFileType::Directory {
             if name_str.starts_with('.') || SKIP_DIRS.contains(&name_str.as_ref()) {
                 continue;
             }
-            subdirs.push(entry.path());
-        } else if file_type.is_file() {
-            out.push(entry.path());
+            match dir.open_child_directory(&name) {
+                Ok(child) => subdirs.push((child, relative)),
+                Err(error) => tracing::warn!(
+                    entry = %relative.display(),
+                    %error,
+                    "grep: directory changed before secure open"
+                ),
+            }
+        } else if entry.kind == secure_fs::SecureFileType::Regular {
+            *files_scanned += 1;
+            match dir.open_child_regular(&name) {
+                Ok(file) => match grep_one(file, regex, context) {
+                    Ok(hits) => append_hits(
+                        &relative.display().to_string(),
+                        hits,
+                        context,
+                        output,
+                        total_matches,
+                        truncated,
+                    ),
+                    Err(error) => tracing::warn!(
+                        file = %relative.display(),
+                        %error,
+                        "grep: confined file read failed"
+                    ),
+                },
+                Err(error) => tracing::warn!(
+                    file = %relative.display(),
+                    %error,
+                    "grep: file changed before secure open"
+                ),
+            }
+            if *total_matches >= MAX_MATCHES {
+                *truncated = true;
+                return;
+            }
         }
     }
-    for sub in subdirs {
-        collect_files(&sub, out, visited);
+    for (sub, relative) in subdirs {
+        grep_directory(
+            &sub,
+            &relative,
+            regex,
+            context,
+            output,
+            total_matches,
+            files_scanned,
+            visited,
+            truncated,
+        );
+        if *truncated {
+            return;
+        }
+    }
+}
+
+fn append_hits(
+    relative: &str,
+    hits: Vec<Hit>,
+    context: usize,
+    output: &mut Vec<String>,
+    total_matches: &mut usize,
+    truncated: &mut bool,
+) {
+    for hit in hits {
+        if *total_matches >= MAX_MATCHES {
+            *truncated = true;
+            break;
+        }
+        for ctx_line in hit.context_before {
+            output.push(format!("{relative}-{}-{ctx_line}", hit.line_no - 1));
+        }
+        output.push(format!("{relative}:{}:{}", hit.line_no, hit.line));
+        let mut after_no = hit.line_no;
+        for ctx_line in hit.context_after {
+            after_no += 1;
+            output.push(format!("{relative}-{after_no}-{ctx_line}"));
+        }
+        if context > 0 {
+            output.push("--".to_string());
+        }
+        *total_matches += 1;
     }
 }
 
@@ -251,6 +321,7 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>, visited: &mut usize) {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fs;
     use std::fs::File;
     use std::io::Write as _;
     use tempfile::TempDir;
@@ -270,7 +341,7 @@ mod tests {
     /// for every hit, ignoring files that don't contain the pattern.
     #[test]
     fn grep_emits_file_line_match() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         write_file(
             dir.path(),
             "a.rs",
@@ -293,7 +364,7 @@ mod tests {
     /// Pin: `context_lines` = 1 emits the surrounding line on each side.
     #[test]
     fn grep_emits_context_lines() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         write_file(
             dir.path(),
             "ctx.txt",
@@ -317,7 +388,7 @@ mod tests {
     /// Pin: an invalid regex surfaces a clean error instead of panicking.
     #[test]
     fn grep_invalid_regex_errors() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         let mut args = HashMap::new();
         args.insert("pattern".to_string(), json!("[unterminated"));
         args.insert(
@@ -367,7 +438,7 @@ mod tests {
     /// Pin: `case_insensitive=true` matches mixed-case occurrences.
     #[test]
     fn grep_case_insensitive_flag() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         write_file(dir.path(), "x.txt", "HELLO world\n");
         let mut args = HashMap::new();
         args.insert("pattern".to_string(), json!("hello"));
@@ -383,7 +454,7 @@ mod tests {
 
     #[test]
     fn grep_rejects_non_boolean_case_insensitive() {
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::new_in(".").unwrap();
         write_file(dir.path(), "x.txt", "hello\n");
         let mut args = HashMap::new();
         args.insert("pattern".to_string(), json!("hello"));

--- a/src/tools/file/list.rs
+++ b/src/tools/file/list.rs
@@ -1,8 +1,7 @@
-use super::resolve_path;
+use super::{resolve_path, secure_fs};
 use crate::tools::args::ToolArgs as _;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 
 /// List files in a directory.
 ///
@@ -23,7 +22,7 @@ pub fn execute_list_files(args: &HashMap<String, Value>) -> (String, bool) {
         Err(e) => return (e, true),
     };
 
-    match fs::read_dir(&path) {
+    match secure_fs::open_directory(&path).and_then(|directory| directory.entries()) {
         Ok(entries) => {
             // (is_dir, name) tuples — sort puts every dir before every
             // file (false < true under default Ord, so `is_dir`'s
@@ -36,20 +35,9 @@ pub fn execute_list_files(args: &HashMap<String, Value>) -> (String, bool) {
             // model to scan candidates by kind.
             let mut items: Vec<(bool, String)> = Vec::new();
             for entry in entries {
-                match entry {
-                    Ok(entry) => {
-                        let name = entry.file_name().to_string_lossy().to_string();
-                        let is_dir = entry.file_type().is_ok_and(|ft| ft.is_dir());
-                        items.push((is_dir, name));
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "list_files: skipping unreadable entry",
-                        );
-                    }
-                }
+                let name = entry.name.to_string_lossy().to_string();
+                let is_dir = entry.kind == secure_fs::SecureFileType::Directory;
+                items.push((is_dir, name));
             }
             // Primary key: dirs before files (so invert is_dir).
             // Secondary key: name (case-sensitive lexicographic, same as before).
@@ -142,7 +130,7 @@ mod tests {
 
         // Happy path: real call into the production function, confirming
         // it still returns successfully and produces a non-error result.
-        let tmp = tempfile::tempdir().unwrap();
+        let tmp = tempfile::tempdir_in(".").unwrap();
         std::fs::write(tmp.path().join("a.txt"), "x").unwrap();
         let mut args = HashMap::new();
         args.insert("path".to_string(), json!(tmp.path().to_str().unwrap()));

--- a/src/tools/file/mod.rs
+++ b/src/tools/file/mod.rs
@@ -4,6 +4,7 @@ mod grep;
 mod list;
 mod notebook;
 mod read;
+mod secure_fs;
 mod write;
 
 pub use edit::execute_edit_file;
@@ -216,90 +217,17 @@ impl ReadFileTracker {
     }
 }
 
-/// Snapshot of the project root, captured the first time [`resolve_path`] runs.
-///
-/// Pinned at startup so that later `cd`s (via the worktree tool, shell
-/// commands, etc.) cannot move the jail underneath us.
-///
-/// crosslink #981: when `current_dir` or `canonicalize` fail (process started
-/// in a deleted directory, FUSE EIO, etc.) the previous fallback was a bare
-/// `PathBuf::from(".")` — a relative path. Every subsequent
-/// `path_is_within(canonical, &PROJECT_ROOT)` would then compare a fully
-/// canonicalized absolute path against `"."` and reject every file silently,
-/// breaking the entire tool subsystem with no visible error. Surface the
-/// failure: a `warn!` records the underlying cause and we fall back to the
-/// absolute filesystem-root `/` so the jail is conservatively wide-open
-/// rather than uniformly closed — operators see broken behaviour and an
-/// explicit warning instead of a silent dead harness. The follow-up cleanup
-/// (panic-on-startup) is tracked separately; this is the smallest fix that
-/// removes the silent-dead-harness mode.
-static PROJECT_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
-    match std::env::current_dir().and_then(|cwd| cwd.canonicalize()) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "PROJECT_ROOT could not be resolved at startup (current_dir/canonicalize failed); \
-                 file-tool jail will fall back to the filesystem root '/'. crosslink #981",
-            );
-            // Use a path that exists and is a real directory so containment
-            // checks at least return *something* deterministic. `/` matches
-            // every absolute path; the operator will see this in logs and
-            // can correct it. Better than `"."`, which silently broke
-            // every path comparison.
-            #[cfg(unix)]
-            {
-                PathBuf::from("/")
-            }
-            #[cfg(not(unix))]
-            {
-                PathBuf::from("\\")
-            }
-        }
-    }
-});
-
-/// Process temp directory, canonicalized.
-static TEMP_ROOT: LazyLock<Option<PathBuf>> =
-    LazyLock::new(|| std::env::temp_dir().canonicalize().ok());
-
-/// Returns `true` when the path jail is in force.
-///
-/// `OPENCLAUDIA_ALLOW_OUT_OF_ROOT=1` opts out of the project-root + temp-dir
-/// containment requirement. crosslink #982: emit a single `tracing::warn!`
-/// the first time we observe the variable in the disabled state so an
-/// operator who set the flag "just for one test" and forgot has a paper
-/// trail in the logs. We deliberately do not warn on every call (the file
-/// tools call `resolve_path` per operation); the once-per-process latch
-/// keeps the log signal-rich without rate-limiting the file subsystem.
-fn strict_mode() -> bool {
-    let on = !matches!(std::env::var("OPENCLAUDIA_ALLOW_OUT_OF_ROOT"), Ok(ref v) if v == "1");
-    if !on {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        static WARNED: AtomicBool = AtomicBool::new(false);
-        if !WARNED.swap(true, Ordering::SeqCst) {
-            tracing::warn!(
-                env = "OPENCLAUDIA_ALLOW_OUT_OF_ROOT",
-                "file-path jail DISABLED: OPENCLAUDIA_ALLOW_OUT_OF_ROOT=1 is set; \
-                 file tools may read/write outside the project root. crosslink #982",
-            );
-        }
-    }
-    on
-}
-
-fn path_is_within(canonical: &Path, root: &Path) -> bool {
-    canonical == root || canonical.starts_with(root)
+fn project_root() -> Result<PathBuf, String> {
+    crate::tools::security::current_context().map(|context| context.project_root().to_path_buf())
 }
 
 fn resolve_path(path: &str) -> Result<PathBuf, String> {
+    let security = crate::tools::security::current_context()?;
     let p = Path::new(path);
     let absolute = if p.is_absolute() {
         p.to_path_buf()
     } else {
-        std::env::current_dir()
-            .map_err(|e| format!("Cannot resolve relative path (no working directory): {e}"))?
-            .join(p)
+        security.working_directory().join(p)
     };
     if absolute
         .components()
@@ -330,22 +258,27 @@ fn resolve_path(path: &str) -> Result<PathBuf, String> {
         }
         built
     };
-    if strict_mode() {
-        let in_project = path_is_within(&canonical, &PROJECT_ROOT);
-        let in_temp = TEMP_ROOT
-            .as_ref()
-            .is_some_and(|t| path_is_within(&canonical, t));
-        if !in_project && !in_temp {
-            return Err(format!(
-                "Path '{path}' resolves to '{}' which is outside the project root ('{}') \
-                 and outside the process temp directory. Set \
-                 OPENCLAUDIA_ALLOW_OUT_OF_ROOT=1 to disable this jail (not recommended).",
-                canonical.display(),
-                PROJECT_ROOT.display(),
-            ));
-        }
+    if !security.permits_read(&canonical) {
+        return Err(format!(
+            "Path '{path}' resolves to '{}' which is outside the session's granted roots \
+             (project '{}', private temp '{}').",
+            canonical.display(),
+            security.project_root().display(),
+            security.private_temp_root().display(),
+        ));
     }
     Ok(canonical)
+}
+
+/// Open an agent-supplied path through the same immutable capability and
+/// descriptor-relative traversal used by `read_file`.
+///
+/// Agent-adjacent consumers such as the LSP adapter must use this rather than
+/// reopening a validated path by name.
+pub fn open_capability_regular_read(user_path: &str) -> Result<(PathBuf, std::fs::File), String> {
+    let resolved = resolve_path(user_path)?;
+    let file = secure_fs::open_regular_read(&resolved)?;
+    Ok((resolved, file))
 }
 
 /// Canonicalise a path that may not yet exist by walking the deepest
@@ -388,13 +321,12 @@ pub(super) fn canonicalize_or_walk_up(p: &Path, user_path: &str) -> Result<PathB
 }
 
 pub fn resolve_open_path(user_path: &str) -> Result<PathBuf, String> {
+    let security = crate::tools::security::current_context()?;
     let p = Path::new(user_path);
     let absolute = if p.is_absolute() {
         p.to_path_buf()
     } else {
-        std::env::current_dir()
-            .map_err(|e| format!("Cannot resolve relative path (no working directory): {e}"))?
-            .join(p)
+        security.working_directory().join(p)
     };
     if absolute
         .components()
@@ -432,20 +364,14 @@ pub fn resolve_open_path(user_path: &str) -> Result<PathBuf, String> {
         built
     };
     let containment_probe = canonical_parent.join(leaf);
-    if strict_mode() {
-        let in_project = path_is_within(&containment_probe, &PROJECT_ROOT);
-        let in_temp = TEMP_ROOT
-            .as_ref()
-            .is_some_and(|t| path_is_within(&containment_probe, t));
-        if !in_project && !in_temp {
-            return Err(format!(
-                "Path '{user_path}' resolves to '{}' which is outside the project root ('{}') \
-                 and outside the process temp directory. Set \
-                 OPENCLAUDIA_ALLOW_OUT_OF_ROOT=1 to disable this jail (not recommended).",
-                containment_probe.display(),
-                PROJECT_ROOT.display(),
-            ));
-        }
+    if !security.permits_write(&containment_probe) {
+        return Err(format!(
+            "Path '{user_path}' resolves to '{}' which is outside the session's writable roots \
+             (project '{}', private temp '{}').",
+            containment_probe.display(),
+            security.project_root().display(),
+            security.private_temp_root().display(),
+        ));
     }
     Ok(canonical_parent.join(leaf))
 }
@@ -568,7 +494,7 @@ pub(super) fn require_fresh_file_observation_if_ledger_active(
 }
 
 fn read_file_bytes_for_ledger(path: &Path) -> std::io::Result<Vec<u8>> {
-    let file = std::fs::File::open(path)?;
+    let file = secure_fs::open_regular_read(path).map_err(std::io::Error::other)?;
     let mut bytes = Vec::new();
     file.take(read::MAX_FILE_SIZE_BYTES)
         .read_to_end(&mut bytes)?;
@@ -668,8 +594,8 @@ mod tests {
         PathBuf,
         PathBuf,
     ) {
-        let a = tempfile::NamedTempFile::new().expect("tempfile a");
-        let b = tempfile::NamedTempFile::new().expect("tempfile b");
+        let a = tempfile::NamedTempFile::new_in(".").expect("tempfile a");
+        let b = tempfile::NamedTempFile::new_in(".").expect("tempfile b");
         let pa = a.path().canonicalize().expect("canonicalize a");
         let pb = b.path().canonicalize().expect("canonicalize b");
         (a, b, pa, pb)
@@ -819,7 +745,7 @@ mod tests {
         READ_TRACKER.clear_all();
         let _g = crate::tools::SessionIdGuard::set("session-363-rel-abs");
 
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in(".").expect("tempdir");
         let canon_dir = dir.path().canonicalize().expect("canonicalize dir");
         let abs_file = canon_dir.join("rel_target.txt");
         std::fs::write(&abs_file, b"hello").expect("write file");
@@ -854,7 +780,7 @@ mod tests {
 
         // Path under a real tempdir but with a leaf that does not exist
         // on disk: canonicalize on the leaf will fail.
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in(".").expect("tempdir");
         let ghost = dir.path().join("does_not_exist_12345.txt");
         assert!(
             !ghost.exists(),
@@ -896,7 +822,7 @@ mod tests {
         READ_TRACKER.clear_all();
         let _g = crate::tools::SessionIdGuard::set("session-363-concurrent");
 
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in(".").expect("tempdir");
         let canon_dir = dir.path().canonicalize().expect("canonicalize dir");
 
         let mut paths: Vec<PathBuf> = Vec::with_capacity(N);

--- a/src/tools/file/notebook.rs
+++ b/src/tools/file/notebook.rs
@@ -6,27 +6,6 @@ use std::fmt::Write as _;
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::Path;
 
-/// Open the notebook ONCE with `O_NOFOLLOW` on the leaf. All reads/writes go
-/// through this single file handle — closing the TOCTOU window between
-/// canonicalize and write described in crosslink #417 (dup #428).
-#[cfg(unix)]
-fn open_notebook_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt;
-    std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-}
-
-#[cfg(not(unix))]
-fn open_notebook_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
-    std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(path)
-}
-
 /// Split source text into a JSON array of line strings for notebook cell source format.
 /// Each line except possibly the last ends with '\n'.
 #[must_use]
@@ -271,10 +250,9 @@ fn preflight_and_open(raw_path: &str) -> Result<NotebookHandle, ToolFailure> {
 
     crate::guardrails::check_file_access(&canonical_path).map_err(|msg| (msg, true))?;
 
-    // Open ONCE with O_NOFOLLOW against the LEAF-PRESERVING path. All
-    // subsequent reads/writes use this FD — closing the TOCTOU window
-    // described in crosslink #417 (dup #428).
-    let file = open_notebook_nofollow(&open_path).map_err(|e| {
+    // Open once through the capability-root descriptor. `openat2` rejects
+    // symlinks in every component, not just the final notebook name.
+    let file = super::secure_fs::open_regular_edit(&open_path).map_err(|e| {
         (
             format!("Failed to open notebook '{canonical_path}': {e}"),
             true,
@@ -686,7 +664,7 @@ mod tests {
     /// Write a notebook JSON to a `NamedTempFile`, mark it read in `READ_TRACKER`,
     /// and return (file, `canonical_path_string`).
     fn tmp_notebook(nb: &Value) -> (NamedTempFile, String) {
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         let text = serde_json::to_string_pretty(nb).expect("serialize");
         f.write_all(text.as_bytes()).expect("write");
         let canon = f.path().canonicalize().expect("canonicalize");
@@ -1092,7 +1070,7 @@ mod tests {
     #[test]
     fn notebook_invalid_json_returns_error() {
         // Behavior 7 error path: invalid JSON → error (both CC and OC agree)
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         f.write_all(b"not valid json {{{{").expect("write");
         let canon = f.path().canonicalize().expect("canon");
         READ_TRACKER.mark_read(&canon);
@@ -1172,7 +1150,7 @@ mod tests {
     #[test]
     fn fix417_notebook_rejects_symlink_at_target() {
         use tempfile::TempDir;
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let target = dir.path().join("attacker_target.ipynb");
         let nb = make_notebook(&json!([
             {"id": "guarded", "cell_type": "code", "source": "SAFE", "metadata": {}, "outputs": [], "execution_count": null}

--- a/src/tools/file/read.rs
+++ b/src/tools/file/read.rs
@@ -2,7 +2,6 @@ use base64::Engine;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Write as _;
-use std::fs;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -40,30 +39,24 @@ fn pdfinfo_bin() -> Option<&'static Path> {
     (*PDFINFO_BIN).as_deref()
 }
 
-/// Return `(error_message, is_error=true)` if `path` is too large or is a
-/// special device file that bypasses the size check (e.g., `/dev/zero`
-/// reports `len()==0` but is effectively infinite).
-fn check_file_safety(path: &str) -> Option<(String, bool)> {
-    let meta = match fs::metadata(path) {
+/// Return `(error_message, is_error=true)` if an already-confined open handle
+/// is too large or is not a regular file. Authorization and inspection must
+/// apply to the same kernel object; checking a pathname here would reopen the
+/// TOCTOU window closed by `secure_fs`.
+fn check_file_safety(file: &std::fs::File, path: &str) -> Option<(String, bool)> {
+    let meta = match file.metadata() {
         Ok(m) => m,
-        Err(e) => return Some((format!("Cannot stat '{path}': {e}"), true)),
+        Err(e) => return Some((format!("Cannot inspect open file '{path}': {e}"), true)),
     };
 
-    // On Unix, block character devices, block devices, FIFOs, and sockets —
-    // these can have metadata.len()==0 but produce unbounded data on read.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::FileTypeExt as _;
-        let ft = meta.file_type();
-        if ft.is_char_device() || ft.is_block_device() || ft.is_fifo() || ft.is_socket() {
-            return Some((
-                format!(
-                    "File '{path}' is a special device (char/block/fifo/socket) and cannot be \
-                     read safely. Provide a regular file path."
-                ),
-                true,
-            ));
-        }
+    if !meta.file_type().is_file() {
+        return Some((
+            format!(
+                "File '{path}' is not a regular file and cannot be read safely. \
+                 Directories, devices, FIFOs, and sockets are not file-tool capabilities."
+            ),
+            true,
+        ));
     }
 
     if meta.len() > MAX_FILE_SIZE_BYTES {
@@ -78,6 +71,36 @@ fn check_file_safety(path: &str) -> Option<(String, bool)> {
     }
 
     None
+}
+
+fn open_safe_read(path: &str) -> Result<std::fs::File, (String, bool)> {
+    let file = super::secure_fs::open_regular_read(Path::new(path)).map_err(|error| {
+        (
+            format!("Failed to securely open file '{path}': {error}"),
+            true,
+        )
+    })?;
+    if let Some(error) = check_file_safety(&file, path) {
+        return Err(error);
+    }
+    Ok(file)
+}
+
+fn read_safe_bytes(path: &str) -> Result<Vec<u8>, (String, bool)> {
+    let file = open_safe_read(path)?;
+    let mut bytes = Vec::new();
+    file.take(MAX_FILE_SIZE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| (format!("Failed to read file '{path}': {error}"), true))?;
+    if bytes.len() > usize::try_from(MAX_FILE_SIZE_BYTES).unwrap_or(usize::MAX) {
+        return Err((
+            format!(
+                "File '{path}' grew beyond the {MAX_FILE_SIZE_BYTES}-byte safety cap while it was being read"
+            ),
+            true,
+        ));
+    }
+    Ok(bytes)
 }
 
 /// Image formats the harness can hand to vision-capable models.
@@ -160,18 +183,9 @@ pub fn detect_file_type(path: &str) -> FileType {
 /// rather than as a raw MIME-type `&str`, so callers can no longer fabricate a
 /// nonsense MIME like `"image/whatever"` at the call site.
 pub fn read_image_file(path: &str, kind: ImageKind) -> (String, bool) {
-    if let Some(err) = check_file_safety(path) {
-        return err;
-    }
-    let bytes = match fs::File::open(path) {
-        Ok(f) => {
-            let mut buf = Vec::new();
-            if let Err(e) = f.take(MAX_FILE_SIZE_BYTES).read_to_end(&mut buf) {
-                return (format!("Failed to read image file '{path}': {e}"), true);
-            }
-            buf
-        }
-        Err(e) => return (format!("Failed to read image file '{path}': {e}"), true),
+    let bytes = match read_safe_bytes(path) {
+        Ok(bytes) => bytes,
+        Err(error) => return error,
     };
 
     // Fail fast at the boundary: a 0-byte image is never valid input for any
@@ -270,7 +284,7 @@ const PDF_TIMEOUT_SECS: u64 = 30;
 /// # Subprocess hardening
 ///
 /// `pdftotext` and `pdfinfo` are spawned via
-/// [`crate::tools::command::run_with_timeout`] with a 30 s deadline so
+/// [`crate::tools::command::run_sandboxed_with_timeout`] with a 30 s deadline so
 /// a malformed PDF cannot pin the worker (crosslink #827, #836). Both
 /// stdout and stderr are captured (`Stdio::piped`); on a non-zero
 /// exit, the stderr tail is included in the error message so the
@@ -294,6 +308,17 @@ pub fn read_pdf_file(path: &str, pages: Option<&str>) -> (String, bool) {
         Ok(path) => path,
         Err(msg) => return (msg, true),
     };
+    let project_root = match super::project_root() {
+        Ok(root) => root,
+        Err(message) => return (message, true),
+    };
+    // Feed the parser bytes read from the already-confined descriptor. Passing
+    // the original pathname would let a concurrent rename swap the parser's
+    // input after authorization.
+    let pdf_bytes = match read_safe_bytes(path) {
+        Ok(bytes) => bytes,
+        Err(error) => return error,
+    };
 
     let timeout = std::time::Duration::from_secs(PDF_TIMEOUT_SECS);
 
@@ -301,11 +326,15 @@ pub fn read_pdf_file(path: &str, pages: Option<&str>) -> (String, bool) {
     if pages.is_none() {
         // `--` terminates options so a hostile filename cannot be parsed as a flag
         // (defence-in-depth alongside reject_flag_prefix above).
-        let info_args = ["--", path];
+        let info_args = ["--", "-"];
         if let Some(pdfinfo) = pdfinfo_bin() {
-            if let Ok(info) =
-                crate::tools::command::run_with_timeout(pdfinfo, &info_args, None, timeout)
-            {
+            if let Ok(info) = crate::tools::command::run_sandboxed_with_timeout_with_input(
+                pdfinfo,
+                &info_args,
+                &project_root,
+                timeout,
+                &pdf_bytes,
+            ) {
                 if info.status.success() {
                     let info_text = String::from_utf8_lossy(&info.stdout);
                     for line in info_text.lines() {
@@ -348,11 +377,17 @@ pub fn read_pdf_file(path: &str, pages: Option<&str>) -> (String, bool) {
         }
     }
     argv.push("--".to_string());
-    argv.push(path.to_string());
+    argv.push("-".to_string()); // stdin, from the confined file descriptor
     argv.push("-".to_string()); // stdout sentinel
     let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
 
-    match crate::tools::command::run_with_timeout(pdftotext, &argv_refs, None, timeout) {
+    match crate::tools::command::run_sandboxed_with_timeout_with_input(
+        pdftotext,
+        &argv_refs,
+        &project_root,
+        timeout,
+        &pdf_bytes,
+    ) {
         Ok(output) => {
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
@@ -471,18 +506,13 @@ fn render_cell_outputs(output: &mut String, outputs: &[Value]) {
 
 /// Read a Jupyter notebook (.ipynb) and format cells for display
 pub fn read_notebook_file(path: &str) -> (String, bool) {
-    if let Some(err) = check_file_safety(path) {
-        return err;
-    }
-    let content = match fs::File::open(path) {
-        Ok(f) => {
-            let mut buf = String::new();
-            if let Err(e) = f.take(MAX_FILE_SIZE_BYTES).read_to_string(&mut buf) {
-                return (format!("Failed to read notebook '{path}': {e}"), true);
-            }
-            buf
-        }
-        Err(e) => return (format!("Failed to read notebook '{path}': {e}"), true),
+    let mut file = match open_safe_read(path) {
+        Ok(file) => file,
+        Err(error) => return error,
+    };
+    let content = match super::secure_fs::read_to_string(&mut file, Path::new(path)) {
+        Ok(content) => content,
+        Err(error) => return (error, true),
     };
 
     let notebook: Value = match serde_json::from_str(&content) {
@@ -530,10 +560,6 @@ pub fn read_notebook_file(path: &str) -> (String, bool) {
 }
 /// Read a plain text file with optional offset/limit
 pub fn read_text_file(path: &str, args: &HashMap<String, Value>) -> (String, bool) {
-    if let Some(err) = check_file_safety(path) {
-        return err;
-    }
-
     // Get optional offset (1-indexed line number to start from)
     let offset = match parse_read_offset_arg(args.get("offset")) {
         Ok(offset) => offset,
@@ -546,15 +572,13 @@ pub fn read_text_file(path: &str, args: &HashMap<String, Value>) -> (String, boo
         Err(msg) => return (msg, true),
     };
 
-    let file_content = match fs::File::open(path) {
-        Ok(f) => {
-            let mut buf = String::new();
-            if let Err(e) = f.take(MAX_FILE_SIZE_BYTES).read_to_string(&mut buf) {
-                return (format!("Failed to read file '{path}': {e}"), true);
-            }
-            buf
-        }
-        Err(e) => return (format!("Failed to read file '{path}': {e}"), true),
+    let mut file = match open_safe_read(path) {
+        Ok(file) => file,
+        Err(error) => return error,
+    };
+    let file_content = match super::secure_fs::read_to_string(&mut file, Path::new(path)) {
+        Ok(content) => content,
+        Err(error) => return (error, true),
     };
 
     let lines: Vec<&str> = file_content.lines().collect();
@@ -663,7 +687,7 @@ mod tests {
 
     /// Helper: write content to a `NamedTempFile` and return (file, `path_string`).
     fn tmp_text(content: &str) -> (NamedTempFile, String) {
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         f.write_all(content.as_bytes()).expect("write");
         let path = f.path().to_string_lossy().to_string();
         (f, path)
@@ -801,14 +825,16 @@ mod tests {
 
     #[test]
     fn read_text_missing_file_returns_error() {
-        // Behavior 1 error path: file not found.
-        // check_file_safety now stats the file first, so the error comes from
-        // the stat call ("Cannot stat") rather than the open ("Failed to read").
+        // Keep the nonexistent fixture inside the readable capability so this
+        // exercises secure-open ENOENT rather than the outer capability gate.
+        let path = std::env::current_dir()
+            .expect("cwd")
+            .join("__oc_test_does_not_exist_xyz.txt");
         let args = HashMap::new();
-        let (output, is_err) = read_text_file("/tmp/__oc_test_does_not_exist_xyz.txt", &args);
+        let (output, is_err) = read_text_file(&path.to_string_lossy(), &args);
         assert!(is_err);
         assert!(
-            output.contains("Cannot stat") || output.contains("Failed to read file"),
+            output.contains("does not exist") || output.contains("securely open"),
             "error message: {output}"
         );
     }
@@ -821,7 +847,7 @@ mod tests {
     fn read_image_returns_base64_text_block() {
         // Behavior 2: OC returns a plain-text string with base64 inline
         // (not a structured image block — CC parity gap, pinned as current behavior).
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         // Minimal valid PNG bytes (1×1 red pixel)
         let minimal_png: &[u8] = &[
             0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // signature
@@ -850,7 +876,7 @@ mod tests {
         // Behavior 2 edge: empty image file is rejected at the boundary
         // (crosslink #942 — previously OC accepted 0-byte images and let the
         // upstream vision API reject the empty base64 after a turn was burned).
-        let f = NamedTempFile::new().expect("tempfile");
+        let f = NamedTempFile::new_in(".").expect("tempfile");
         // Write nothing — file is 0 bytes
         let path = f.path().to_string_lossy().to_string();
         let (output, is_err) = read_image_file(&path, ImageKind::Png);
@@ -863,13 +889,13 @@ mod tests {
 
     #[test]
     fn read_image_nonexistent_returns_error() {
-        // Behavior 2 error path: file not found.
-        // check_file_safety stats first, so the message may be "Cannot stat"
-        // rather than "Failed to read image file".
-        let (output, is_err) = read_image_file("/tmp/__oc_no_such_image.png", ImageKind::Png);
+        let path = std::env::current_dir()
+            .expect("cwd")
+            .join("__oc_no_such_image.png");
+        let (output, is_err) = read_image_file(&path.to_string_lossy(), ImageKind::Png);
         assert!(is_err);
         assert!(
-            output.contains("Cannot stat") || output.contains("Failed to read image file"),
+            output.contains("does not exist") || output.contains("securely open"),
             "error message: {output}"
         );
     }
@@ -933,7 +959,7 @@ mod tests {
                                            // Need > 100_000 chars in the numbered output: with "   N| " prefix (~7 chars)
                                            // each line becomes ~208 chars; 600 lines = ~124 800 chars → triggers truncation.
         let content = line.repeat(600);
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         f.write_all(content.as_bytes()).expect("write");
         let path = f.path().to_string_lossy().to_string();
         let args = HashMap::new();
@@ -978,7 +1004,7 @@ mod tests {
 
     /// Helper: write `size` bytes of 'a' to a temp file.
     fn tmp_sized(size: usize) -> (NamedTempFile, String) {
-        let mut f = NamedTempFile::new().expect("tempfile");
+        let mut f = NamedTempFile::new_in(".").expect("tempfile");
         let buf = vec![b'a'; size];
         f.write_all(&buf).expect("write");
         let path = f.path().to_string_lossy().to_string();
@@ -1015,7 +1041,7 @@ mod tests {
     fn read_text_empty_file_is_ok() {
         // Behavior 9 edge: zero-byte regular file — not a device, not oversized.
         // Must succeed with an empty body.
-        let f = NamedTempFile::new().expect("tempfile");
+        let f = NamedTempFile::new_in(".").expect("tempfile");
         let path = f.path().to_string_lossy().to_string();
         let args = HashMap::new();
         let (output, is_err) = read_text_file(&path, &args);
@@ -1024,15 +1050,15 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn read_text_char_device_is_rejected() {
-        // Behavior 9 (Unix): /dev/null is a char device; metadata.len()==0 but
-        // check_file_safety must reject it before any read attempt.
+    fn read_text_device_outside_capability_is_rejected() {
+        // Devices are never session file capabilities. The outer capability
+        // check should reject /dev before the implementation can open it.
         let args = HashMap::new();
         let (output, is_err) = read_text_file("/dev/null", &args);
         assert!(is_err, "/dev/null (char device) must be rejected: {output}");
         assert!(
-            output.contains("special device"),
-            "error must mention 'special device': {output}"
+            output.contains("outside the session") || output.contains("not a regular file"),
+            "error must explain the capability/type denial: {output}"
         );
     }
 

--- a/src/tools/file/secure_fs.rs
+++ b/src/tools/file/secure_fs.rs
@@ -1,0 +1,726 @@
+//! Handle-relative filesystem access for agent file tools.
+//!
+//! Path canonicalization is useful for diagnostics but is not an authorization
+//! primitive: an attacker can replace an intermediate directory after the
+//! check. On Linux these helpers anchor resolution at an open capability-root
+//! descriptor and use `openat2(2)` with `RESOLVE_BENEATH`,
+//! `RESOLVE_NO_MAGICLINKS`, and `RESOLVE_NO_SYMLINKS`.
+
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{Read as _, Seek as _, SeekFrom};
+use std::path::{Path, PathBuf};
+
+/// Open an existing regular file for reading without following any symlink
+/// during the authoritative kernel lookup.
+pub(super) fn open_regular_read(path: &Path) -> Result<File, String> {
+    let file = open_beneath(path, false, libc_flags::O_RDONLY, 0)?;
+    require_regular(&file, path)?;
+    reject_readable_hardlink(&file, path)?;
+    Ok(file)
+}
+
+/// Open a regular file for an in-place edit.
+pub(super) fn open_regular_edit(path: &Path) -> Result<File, String> {
+    let file = open_beneath(path, true, libc_flags::O_RDWR, 0)?;
+    require_regular(&file, path)?;
+    reject_writable_hardlink(&file, path)?;
+    Ok(file)
+}
+
+/// Open an existing file for update, or securely create it and any missing
+/// parent directories. Returns `(file, existed_before_open)`.
+pub(super) fn open_regular_update_or_create(path: &Path) -> Result<(File, bool), String> {
+    match open_beneath(path, true, libc_flags::O_RDWR, 0) {
+        Ok(file) => {
+            require_regular(&file, path)?;
+            reject_writable_hardlink(&file, path)?;
+            Ok((file, true))
+        }
+        Err(error) if is_not_found_message(&error) => {
+            create_parent_directories(path)?;
+            let file = open_beneath(
+                path,
+                true,
+                libc_flags::O_RDWR | libc_flags::O_CREAT | libc_flags::O_EXCL,
+                0o666,
+            )?;
+            require_regular(&file, path)?;
+            Ok((file, false))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// A directory pinned to the kernel object reached through a capability root.
+pub(super) struct SecureDirectory {
+    #[cfg(unix)]
+    file: File,
+    #[cfg(unix)]
+    display_path: PathBuf,
+}
+
+pub(super) struct SecureDirEntry {
+    pub(super) name: OsString,
+    pub(super) kind: SecureFileType,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum SecureFileType {
+    Directory,
+    Regular,
+    Other,
+}
+
+#[cfg(unix)]
+struct Directory(*mut libc::DIR);
+
+#[cfg(unix)]
+impl Drop for Directory {
+    fn drop(&mut self) {
+        // SAFETY: the guard uniquely owns the DIR pointer.
+        unsafe {
+            libc::closedir(self.0);
+        }
+    }
+}
+
+/// Open a directory without following symlinks in any path component.
+#[cfg(unix)]
+pub(super) fn open_directory(path: &Path) -> Result<SecureDirectory, String> {
+    let file = open_beneath(
+        path,
+        false,
+        libc_flags::O_RDONLY | libc_flags::O_DIRECTORY,
+        0,
+    )?;
+    require_directory(&file, path)?;
+    Ok(SecureDirectory {
+        file,
+        display_path: path.to_path_buf(),
+    })
+}
+
+#[cfg(not(unix))]
+pub(super) fn open_directory(_path: &Path) -> Result<SecureDirectory, String> {
+    Err(
+        "Directory operation is blocked: this platform lacks a race-safe handle-relative filesystem backend"
+            .to_string(),
+    )
+}
+
+#[cfg(unix)]
+impl SecureDirectory {
+    /// Enumerate names relative to this pinned directory descriptor. Entry
+    /// types are inspected with `fstatat(..., AT_SYMLINK_NOFOLLOW)`.
+    pub(super) fn entries(&self) -> Result<Vec<SecureDirEntry>, String> {
+        read_directory_entries(&self.file, &self.display_path)
+    }
+
+    /// Securely enter one direct child directory.
+    pub(super) fn open_child_directory(&self, name: &std::ffi::OsStr) -> Result<Self, String> {
+        let relative = single_component(name)?;
+        let file = openat2_relative(
+            &self.file,
+            &relative,
+            libc_flags::O_RDONLY | libc::O_DIRECTORY,
+            0,
+        )
+        .map_err(|error| {
+            format!(
+                "Failed to securely enter '{}' below '{}': {error}",
+                name.to_string_lossy(),
+                self.display_path.display()
+            )
+        })?;
+        let display_path = self.display_path.join(name);
+        require_directory(&file, &display_path)?;
+        Ok(Self { file, display_path })
+    }
+
+    /// Securely open one direct regular-file child for reading.
+    pub(super) fn open_child_regular(&self, name: &std::ffi::OsStr) -> Result<File, String> {
+        let relative = single_component(name)?;
+        let file =
+            openat2_relative(&self.file, &relative, libc_flags::O_RDONLY, 0).map_err(|error| {
+                format!(
+                    "Failed to securely open '{}' below '{}': {error}",
+                    name.to_string_lossy(),
+                    self.display_path.display()
+                )
+            })?;
+        require_regular(&file, &self.display_path.join(name))?;
+        reject_readable_hardlink(&file, &self.display_path.join(name))?;
+        Ok(file)
+    }
+}
+
+#[cfg(not(unix))]
+impl SecureDirectory {
+    pub(super) fn entries(&self) -> Result<Vec<SecureDirEntry>, String> {
+        Err(
+            "Directory operation is blocked: this platform lacks a race-safe handle-relative filesystem backend"
+                .to_string(),
+        )
+    }
+
+    pub(super) fn open_child_directory(&self, _name: &std::ffi::OsStr) -> Result<Self, String> {
+        Err(
+            "Directory traversal is blocked: this platform lacks a race-safe handle-relative filesystem backend"
+                .to_string(),
+        )
+    }
+
+    pub(super) fn open_child_regular(&self, _name: &std::ffi::OsStr) -> Result<File, String> {
+        Err(
+            "File operation is blocked: this platform lacks a race-safe handle-relative filesystem backend"
+                .to_string(),
+        )
+    }
+}
+
+/// Read a UTF-8 file from its already confined handle.
+pub(super) fn read_to_string(file: &mut File, path: &Path) -> Result<String, String> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| format!("Failed to seek '{}': {error}", path.display()))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .map_err(|error| format!("Failed to read '{}': {error}", path.display()))?;
+    Ok(content)
+}
+
+fn require_regular(file: &File, path: &Path) -> Result<(), String> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("Failed to inspect '{}': {error}", path.display()))?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Refusing non-regular file '{}': directories, sockets, FIFOs, and devices are not file-tool capabilities",
+            path.display()
+        ))
+    }
+}
+
+fn require_directory(file: &File, path: &Path) -> Result<(), String> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("Failed to inspect '{}': {error}", path.display()))?;
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(format!("'{}' is not a directory", path.display()))
+    }
+}
+
+#[cfg(unix)]
+fn reject_writable_hardlink(file: &File, path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt as _;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("Failed to inspect '{}': {error}", path.display()))?;
+    if metadata.nlink() > 1 {
+        return Err(format!(
+            "Refusing to modify '{}' because it has {} hardlinks; another name may be outside the session capability roots",
+            path.display(),
+            metadata.nlink()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn reject_readable_hardlink(file: &File, path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt as _;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("Failed to inspect '{}': {error}", path.display()))?;
+    if metadata.nlink() > 1 {
+        return Err(format!(
+            "Refusing to read '{}' because it has {} hardlinks; another name may be a masked control or secret path",
+            path.display(),
+            metadata.nlink()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_readable_hardlink(_file: &File, _path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_writable_hardlink(_file: &File, _path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn is_not_found_message(error: &str) -> bool {
+    error.starts_with("NOT_FOUND:")
+}
+
+#[cfg(target_os = "linux")]
+fn open_beneath(path: &Path, write: bool, flags: i32, mode: u32) -> Result<File, String> {
+    let context = crate::tools::security::current_context()?;
+    let (root, root_fd) = context.root_handle_for(path, write)?;
+    let relative = relative_to_root(path, root)?;
+    openat2_relative(root_fd, &relative, flags, mode).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            format!("NOT_FOUND: '{}' does not exist", path.display())
+        } else {
+            format!(
+                "Secure open of '{}' below '{}' failed: {error}",
+                path.display(),
+                root.display()
+            )
+        }
+    })
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn open_beneath(path: &Path, write: bool, flags: i32, mode: u32) -> Result<File, String> {
+    let context = crate::tools::security::current_context()?;
+    let (root, root_fd) = context.root_handle_for(path, write)?;
+    let relative = relative_to_root(path, root)?;
+    openat_walk(root_fd, &relative, flags, mode).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            format!("NOT_FOUND: '{}' does not exist", path.display())
+        } else {
+            format!(
+                "Secure descriptor-relative open of '{}' below '{}' failed: {error}",
+                path.display(),
+                root.display()
+            )
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn open_beneath(_path: &Path, _write: bool, _flags: i32, _mode: u32) -> Result<File, String> {
+    Err(
+        "File operation is blocked: this platform does not yet provide a race-safe handle-relative filesystem backend"
+            .to_string(),
+    )
+}
+
+/// Descriptor-relative component walk for Unix platforms without `openat2`
+/// (notably macOS). Every intermediate descriptor is opened with
+/// `O_NOFOLLOW`; `..`, roots, and prefixes are rejected before any syscall.
+#[cfg(all(unix, not(target_os = "linux")))]
+fn openat_walk(root_fd: &File, relative: &Path, flags: i32, mode: u32) -> std::io::Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let duplicated = unsafe { libc::fcntl(root_fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let mut current = unsafe { OwnedFd::from_raw_fd(duplicated) };
+    let components: Vec<_> = relative.components().collect();
+    if components.is_empty() {
+        return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+    }
+    for (index, component) in components.iter().enumerate() {
+        let std::path::Component::Normal(name) = component else {
+            if matches!(component, std::path::Component::CurDir) && components.len() == 1 {
+                let duplicate =
+                    unsafe { libc::fcntl(current.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+                if duplicate < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                return Ok(unsafe { File::from_raw_fd(duplicate) });
+            }
+            return Err(std::io::Error::from_raw_os_error(libc::EPERM));
+        };
+        let name = CString::new(name.as_bytes())
+            .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+        let is_last = index + 1 == components.len();
+        let open_flags = if is_last {
+            flags | libc::O_CLOEXEC | libc::O_NOFOLLOW
+        } else {
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW
+        };
+        let fd = unsafe { libc::openat(current.as_raw_fd(), name.as_ptr(), open_flags, mode) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if is_last {
+            return Ok(unsafe { File::from_raw_fd(fd) });
+        }
+        current = unsafe { OwnedFd::from_raw_fd(fd) };
+    }
+    Err(std::io::Error::from_raw_os_error(libc::EINVAL))
+}
+
+#[cfg(target_os = "linux")]
+fn openat2_relative(
+    root_fd: &File,
+    relative: &Path,
+    flags: i32,
+    mode: u32,
+) -> std::io::Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+    use std::os::unix::ffi::OsStrExt as _;
+
+    #[repr(C)]
+    struct OpenHow {
+        flags: u64,
+        mode: u64,
+        resolve: u64,
+    }
+    const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
+    const RESOLVE_NO_SYMLINKS: u64 = 0x04;
+    const RESOLVE_BENEATH: u64 = 0x08;
+
+    let relative_c = CString::new(relative.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let how = OpenHow {
+        flags: u64::try_from(flags | libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?,
+        mode: u64::from(mode),
+        resolve: RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_SYMLINKS,
+    };
+    // SAFETY: arguments match the Linux openat2 ABI; `how` and `relative_c`
+    // remain alive for the syscall.
+    let fd = unsafe {
+        libc::syscall(
+            libc::SYS_openat2,
+            root_fd.as_raw_fd(),
+            relative_c.as_ptr(),
+            &raw const how,
+            std::mem::size_of::<OpenHow>(),
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let fd = i32::try_from(fd).map_err(|_| std::io::Error::from_raw_os_error(libc::EOVERFLOW))?;
+    // SAFETY: the successful syscall returned a new owned descriptor.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn create_parent_directories(path: &Path) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let context = crate::tools::security::current_context()?;
+    let (root, root_handle) = context.root_handle_for(path, true)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Path '{}' has no parent", path.display()))?;
+    let relative_parent = relative_to_root(parent, root)?;
+    let duplicated = unsafe { libc::fcntl(root_handle.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated < 0 {
+        return Err(format!(
+            "Failed to duplicate capability root '{}': {}",
+            root.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: `fcntl(F_DUPFD_CLOEXEC)` returned a new owned descriptor.
+    let mut current = unsafe { OwnedFd::from_raw_fd(duplicated) };
+
+    for component in relative_parent.components() {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        let name = CString::new(name.as_bytes()).map_err(|_| {
+            format!(
+                "Directory component contains NUL below '{}'",
+                root.display()
+            )
+        })?;
+        // SAFETY: `current` is an open directory and `name` is NUL-terminated.
+        let mkdir_result = unsafe { libc::mkdirat(current.as_raw_fd(), name.as_ptr(), 0o777) };
+        if mkdir_result != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::AlreadyExists {
+                return Err(format!(
+                    "Failed to create a directory below '{}': {error}",
+                    root.display()
+                ));
+            }
+        }
+        // SAFETY: descriptor-relative lookup with O_NOFOLLOW prevents a
+        // concurrently substituted symlink from becoming the next anchor.
+        #[cfg(target_os = "linux")]
+        let directory_flags = libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        #[cfg(not(target_os = "linux"))]
+        let directory_flags =
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        let next = unsafe { libc::openat(current.as_raw_fd(), name.as_ptr(), directory_flags) };
+        if next < 0 {
+            return Err(format!(
+                "Failed to securely enter a directory below '{}': {}",
+                root.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        // SAFETY: `next` is newly owned; assignment drops the prior anchor.
+        current = unsafe { OwnedFd::from_raw_fd(next) };
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn single_component(name: &std::ffi::OsStr) -> Result<PathBuf, String> {
+    let path = Path::new(name);
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(_)), None) => Ok(path.to_path_buf()),
+        _ => Err(format!(
+            "Refusing non-component directory entry '{}'",
+            name.to_string_lossy()
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn read_directory_entries(file: &File, path: &Path) -> Result<Vec<SecureDirEntry>, String> {
+    use std::ffi::CStr;
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::ffi::OsStringExt as _;
+
+    // `fdopendir` owns its descriptor, so duplicate the pinned handle.
+    // SAFETY: `file` is live for this call.
+    let duplicate = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicate < 0 {
+        return Err(format!(
+            "Failed to duplicate directory '{}': {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: `duplicate` is an open directory descriptor and ownership is
+    // transferred to `fdopendir` on success.
+    let dir = unsafe { libc::fdopendir(duplicate) };
+    if dir.is_null() {
+        // SAFETY: fdopendir failed and did not take ownership.
+        unsafe {
+            libc::close(duplicate);
+        }
+        return Err(format!(
+            "Failed to enumerate directory '{}': {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    let directory = Directory(dir);
+    let mut entries = Vec::new();
+    loop {
+        clear_errno();
+        // SAFETY: the DIR pointer remains live under `directory`.
+        let entry = unsafe { libc::readdir(directory.0) };
+        if entry.is_null() {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(0) {
+                break;
+            }
+            return Err(format!(
+                "Failed while enumerating directory '{}': {error}",
+                path.display()
+            ));
+        }
+        // SAFETY: `readdir` returned a valid dirent with NUL-terminated name.
+        let name_bytes = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+        let name = OsString::from_vec(name_bytes.to_vec());
+        let name_c = std::ffi::CString::new(name_bytes).map_err(|_| {
+            format!(
+                "Directory '{}' contains an entry name with NUL",
+                path.display()
+            )
+        })?;
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: arguments are valid; AT_SYMLINK_NOFOLLOW inspects the entry
+        // itself and cannot redirect the lookup outside this pinned directory.
+        let result = unsafe {
+            libc::fstatat(
+                file.as_raw_fd(),
+                name_c.as_ptr(),
+                stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result != 0 {
+            tracing::warn!(
+                dir = %path.display(),
+                entry = %name.to_string_lossy(),
+                error = %std::io::Error::last_os_error(),
+                "secure directory entry disappeared before inspection"
+            );
+            continue;
+        }
+        // SAFETY: fstatat initialized `stat` on success.
+        let stat = unsafe { stat.assume_init() };
+        let file_kind = stat.st_mode & libc::S_IFMT;
+        let kind = if file_kind == libc::S_IFDIR {
+            SecureFileType::Directory
+        } else if file_kind == libc::S_IFREG {
+            SecureFileType::Regular
+        } else {
+            SecureFileType::Other
+        };
+        let entry_path = path.join(&name);
+        if crate::tools::security::current_context()?.is_denied_path(&entry_path) {
+            tracing::debug!(
+                target: "openclaudia::filesystem",
+                event = "masked_path_hidden",
+                path = %entry_path.display(),
+                "Omitted masked path from agent directory enumeration"
+            );
+            continue;
+        }
+        entries.push(SecureDirEntry { name, kind });
+    }
+    Ok(entries)
+}
+
+#[cfg(target_os = "linux")]
+fn clear_errno() {
+    // SAFETY: Linux exposes thread-local errno through this pointer.
+    unsafe {
+        *libc::__errno_location() = 0;
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn clear_errno() {
+    // SAFETY: Darwin and the supported BSD libc expose thread-local errno
+    // through `__error`.
+    unsafe {
+        *libc::__error() = 0;
+    }
+}
+
+#[cfg(not(unix))]
+fn create_parent_directories(_path: &Path) -> Result<(), String> {
+    Err(
+        "Directory creation is blocked: this platform lacks a race-safe handle-relative filesystem backend"
+            .to_string(),
+    )
+}
+
+#[cfg(not(unix))]
+fn capability_root(path: &Path, write: bool) -> Result<PathBuf, String> {
+    let context = crate::tools::security::current_context()?;
+    let roots = if write {
+        context.read_write_roots()
+    } else {
+        // A read may use either kind. Build a small owned list so longest-root
+        // selection remains deterministic for nested capabilities.
+        return context
+            .read_write_roots()
+            .iter()
+            .chain(context.read_only_roots())
+            .filter(|root| path == root.as_path() || path.starts_with(root))
+            .max_by_key(|root| root.components().count())
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "Path '{}' is outside the session's readable capability roots",
+                    path.display()
+                )
+            });
+    };
+    roots
+        .iter()
+        .filter(|root| path == root.as_path() || path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "Path '{}' is outside the session's writable capability roots",
+                path.display()
+            )
+        })
+}
+
+fn relative_to_root(path: &Path, root: &Path) -> Result<PathBuf, String> {
+    let relative = path.strip_prefix(root).map_err(|error| {
+        format!(
+            "Path '{}' is not below capability root '{}': {error}",
+            path.display(),
+            root.display()
+        )
+    })?;
+    if relative.as_os_str().is_empty() {
+        Ok(PathBuf::from("."))
+    } else {
+        Ok(relative.to_path_buf())
+    }
+}
+
+#[cfg(unix)]
+mod libc_flags {
+    pub(super) const O_RDONLY: i32 = libc::O_RDONLY;
+    pub(super) const O_RDWR: i32 = libc::O_RDWR;
+    pub(super) const O_CREAT: i32 = libc::O_CREAT;
+    pub(super) const O_EXCL: i32 = libc::O_EXCL;
+    pub(super) const O_DIRECTORY: i32 = libc::O_DIRECTORY;
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn openat2_relative(
+    root_fd: &File,
+    relative: &Path,
+    flags: i32,
+    mode: u32,
+) -> std::io::Result<File> {
+    openat_walk(root_fd, relative, flags, mode)
+}
+
+#[cfg(not(unix))]
+mod libc_flags {
+    pub(super) const O_RDONLY: i32 = 0;
+    pub(super) const O_RDWR: i32 = 0;
+    pub(super) const O_CREAT: i32 = 0;
+    pub(super) const O_EXCL: i32 = 0;
+    pub(super) const O_DIRECTORY: i32 = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn control_paths_are_hidden_from_direct_reads_and_directory_enumeration() {
+        let root = tempfile::tempdir().expect("project root");
+        let control = root.path().join(".openclaudia");
+        std::fs::create_dir(&control).expect("control dir");
+        std::fs::write(control.join("canary"), "secret").expect("control canary");
+        std::fs::write(root.path().join("visible"), "public").expect("visible file");
+        let session = format!("secure-fs-control-mask-{}", uuid::Uuid::new_v4());
+        crate::tools::security::register_session_context(
+            &session,
+            root.path(),
+            root.path(),
+            &[],
+            &[],
+        )
+        .expect("security context");
+        let _guard = crate::tools::SessionIdGuard::set(&session);
+
+        let error = open_regular_read(&control.join("canary"))
+            .expect_err("control-plane file must not be readable");
+        assert!(error.contains("masked"), "unexpected denial: {error}");
+        let names: Vec<_> = open_directory(root.path())
+            .expect("project directory")
+            .entries()
+            .expect("secure entries")
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+        assert!(names.contains(&OsString::from("visible")));
+        assert!(!names.contains(&OsString::from(".openclaudia")));
+        crate::tools::security::release_session_context(&session);
+    }
+}

--- a/src/tools/file/write.rs
+++ b/src/tools/file/write.rs
@@ -1,43 +1,10 @@
-use super::{canonicalize_or_walk_up, resolve_open_path, resolve_path, READ_TRACKER};
+use super::{resolve_open_path, resolve_path, secure_fs, READ_TRACKER};
 use crate::tools::args::ToolArgs as _;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Write as _;
-use std::fs;
-use std::io::Write as _;
+use std::io::{Seek as _, SeekFrom, Write as _};
 use std::path::Path;
-
-/// Open a file for writing in a way that refuses to follow a symlink at the
-/// leaf. This closes the TOCTOU window in which an attacker swaps the leaf
-/// for a symlink between [`resolve_path`]'s `canonicalize` and the final
-/// `fs::write` (crosslink #417 / dup #428).
-///
-/// `O_NOFOLLOW` applies to the **last** component of the path only — intermediate
-/// path elements still resolve through symlinks. That is exactly what we want:
-/// the jail check has already vetted the *resolved* path, and `O_NOFOLLOW`
-/// ensures the kernel's `open(2)` call fails with `ELOOP` if the leaf became
-/// a symlink in the meantime.
-#[cfg(unix)]
-fn open_for_write_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt;
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-}
-
-#[cfg(not(unix))]
-fn open_for_write_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
-    // On non-Unix targets we fall back to the standard open. Windows
-    // hardening (FILE_FLAG_OPEN_REPARSE_POINT) is tracked separately.
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)
-}
 
 /// Write content to a file
 pub fn execute_write_file(args: &HashMap<String, Value>) -> (String, bool) {
@@ -60,23 +27,33 @@ pub fn execute_write_file(args: &HashMap<String, Value>) -> (String, bool) {
         Err(e) => return (e, true),
     };
 
-    // crosslink #969: single source of truth for "canonicalize the path, or
-    // walk up to the deepest existing ancestor and rejoin." Edit, write, and
-    // (the next refactor) notebook all share this helper instead of carrying
-    // three drifted copies.
-    let canonical = match canonicalize_or_walk_up(&p, user_path) {
-        Ok(c) => c,
-        Err(e) => return (e, true),
-    };
-    let path = canonical.to_string_lossy().to_string();
+    let path = p.to_string_lossy().to_string();
     let path = path.as_str();
+
+    let content = match args.arg_str_strict("content") {
+        Ok(content) => content,
+        Err(e) => return e.into_tool_error(),
+    };
+
+    if let Err(msg) = crate::guardrails::check_file_access(path) {
+        return (msg, true);
+    }
+
+    let (mut file, target_exists) = match secure_fs::open_regular_update_or_create(&open_path) {
+        Ok(opened) => opened,
+        Err(error) => {
+            return (
+                format!("Failed to securely open file '{path}' for writing: {error}"),
+                true,
+            );
+        }
+    };
 
     // crosslink #968: parity with `edit_file` — require the file to have
     // been read at least once before we overwrite it. A model that
     // writes blindly is hallucinating the old contents; the diff is
     // unverifiable. Creating a new file (path does not exist yet) is
     // exempt because there is no prior content to hallucinate.
-    let target_exists = Path::new(path).exists();
     if target_exists && !READ_TRACKER.has_been_read(Path::new(path)) {
         return (
             format!(
@@ -96,39 +73,22 @@ pub fn execute_write_file(args: &HashMap<String, Value>) -> (String, bool) {
         }
     }
 
-    let content = match args.arg_str_strict("content") {
-        Ok(content) => content,
-        Err(e) => return e.into_tool_error(),
+    let old_content = if target_exists {
+        match secure_fs::read_to_string(&mut file, Path::new(path)) {
+            Ok(content) => content,
+            Err(error) => return (error, true),
+        }
+    } else {
+        String::new()
     };
-
-    if let Err(msg) = crate::guardrails::check_file_access(path) {
-        return (msg, true);
-    }
-
-    let old_content = fs::read_to_string(path).unwrap_or_default();
     let old_lines = u32::try_from(old_content.lines().count()).unwrap_or(u32::MAX);
     let new_lines = u32::try_from(content.lines().count()).unwrap_or(u32::MAX);
 
-    if let Some(parent) = Path::new(path).parent() {
-        if !parent.as_os_str().is_empty() {
-            if let Err(e) = fs::create_dir_all(parent) {
-                return (format!("Failed to create directories: {e}"), true);
-            }
-        }
-    }
-
-    // Open with O_NOFOLLOW against the LEAF-PRESERVING path. See #417.
-    let mut file = match open_for_write_nofollow(&open_path) {
-        Ok(f) => f,
-        Err(e) => {
-            return (
-                format!("Failed to open file '{path}' for writing: {e}"),
-                true,
-            );
-        }
-    };
-
-    match file.write_all(content.as_bytes()) {
+    let write_result = file
+        .seek(SeekFrom::Start(0))
+        .and_then(|_| file.set_len(0))
+        .and_then(|()| file.write_all(content.as_bytes()));
+    match write_result {
         Ok(()) => {
             crate::guardrails::record_file_modification(path, new_lines, old_lines);
             super::record_active_diff_observation(path, &old_content, content);
@@ -164,7 +124,7 @@ mod tests {
 
     #[test]
     fn write_creates_parent_directories_recursively() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let deep = dir.path().join("a").join("b").join("c").join("file.txt");
         let args = make_args(&deep.to_string_lossy(), "hello");
         let (msg, is_err) = super::execute_write_file(&args);
@@ -177,7 +137,7 @@ mod tests {
 
     #[test]
     fn write_success_message_contains_byte_count_and_path() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("out.txt");
         let content = "abc";
         let args = make_args(&path.to_string_lossy(), content);
@@ -190,7 +150,7 @@ mod tests {
     #[test]
     fn write_parent_already_exists_is_idempotent() {
         let _lock = tracker_lock();
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("file.txt");
         let args = make_args(&path.to_string_lossy(), "first");
         let (_, is_err) = super::execute_write_file(&args);
@@ -208,7 +168,7 @@ mod tests {
     #[test]
     fn write_overwrites_existing_file() {
         let _lock = tracker_lock();
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("existing.txt");
         std::fs::write(&path, "old content").expect("setup");
         // crosslink #968: overwrite requires a prior read.
@@ -223,7 +183,7 @@ mod tests {
     #[test]
     fn successful_overwrite_invalidates_prior_read_marker() {
         let _lock = tracker_lock();
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("stale_after_write.txt");
         std::fs::write(&path, "old").expect("setup");
         super::READ_TRACKER.mark_read(&path);
@@ -250,7 +210,7 @@ mod tests {
     fn fix968_overwrite_without_read_is_rejected() {
         let _lock = tracker_lock();
         super::READ_TRACKER.clear_all();
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("must_read_first.txt");
         std::fs::write(&path, "old").expect("setup");
         // Deliberately do NOT mark_read. Overwrite must fail.
@@ -275,7 +235,7 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(crate::ledger::RealityLedger::new()));
         let _ledger_guard =
             crate::ledger::install_active_ledger_for_session("write-ledger-read-required", ledger);
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("ledger_requires_read.txt");
         std::fs::write(&path, "old").expect("setup");
         super::READ_TRACKER.mark_read(&path);
@@ -297,7 +257,7 @@ mod tests {
     /// content, not to gate fresh creation.
     #[test]
     fn fix968_create_new_file_does_not_require_read() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("brand_new_file.txt");
         assert!(!path.exists(), "precondition: target must not exist");
         let args = make_args(&path.to_string_lossy(), "fresh");
@@ -308,7 +268,7 @@ mod tests {
 
     #[test]
     fn write_empty_content_succeeds() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("empty.txt");
         let args = make_args(&path.to_string_lossy(), "");
         let (msg, is_err) = super::execute_write_file(&args);
@@ -319,7 +279,7 @@ mod tests {
 
     #[test]
     fn write_missing_content_arg_returns_error() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("x.txt");
         let mut args = HashMap::new();
         args.insert(
@@ -345,7 +305,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn fix417_write_rejects_symlink_at_target() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let target = dir.path().join("attacker_secrets.txt");
         std::fs::write(&target, "DO NOT OVERWRITE").expect("setup target");
         let leaf = dir.path().join("leaf.txt");
@@ -366,7 +326,7 @@ mod tests {
     #[test]
     fn fix417_write_legitimate_regular_file_still_works() {
         let _lock = tracker_lock();
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("real.txt");
         std::fs::write(&path, "old").expect("setup");
         // crosslink #968: overwrite requires a prior read.
@@ -379,7 +339,7 @@ mod tests {
 
     #[test]
     fn fix417_write_create_new_file_works() {
-        let dir = TempDir::new().expect("tempdir");
+        let dir = TempDir::new_in(".").expect("tempdir");
         let path = dir.path().join("brand_new.txt");
         assert!(!path.exists(), "precondition: file must not exist");
         let args = make_args(&path.to_string_lossy(), "fresh");

--- a/src/tools/file_index.rs
+++ b/src/tools/file_index.rs
@@ -299,7 +299,7 @@ mod tests {
         let index = index_from_paths(&["src/main.rs", "src/domain/maintain.rs"]);
         let results = index.search("main", 10);
         // "main.rs" should score higher (boundary match after /)
-        assert!(results[0].path == "src/main.rs");
+        assert_eq!(results[0].path, "src/main.rs");
     }
 
     #[test]

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::hash::BuildHasher;
 use std::io::{self, BufRead, BufReader, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
@@ -207,11 +208,18 @@ fn resolve_language_server(language_or_ext: &str) -> Option<(&'static str, Vec<&
 /// an un-reaped zombie on Unix and a leaking handle on Windows.
 struct ChildGuard {
     child: Option<Child>,
+    _registration: Option<crate::tools::command::ActiveSandboxProcess>,
 }
 
 impl ChildGuard {
-    const fn new(child: Child) -> Self {
-        Self { child: Some(child) }
+    fn new(child: Child) -> Self {
+        let registration = Some(crate::tools::command::ActiveSandboxProcess::register(
+            child.id(),
+        ));
+        Self {
+            child: Some(child),
+            _registration: registration,
+        }
     }
 
     /// Return a mutable reference to the wrapped child.
@@ -225,7 +233,8 @@ impl ChildGuard {
 impl Drop for ChildGuard {
     fn drop(&mut self) {
         if let Some(mut child) = self.child.take() {
-            // Best-effort kill; ignore errors (process may have already exited).
+            crate::tools::terminate_process_tree(child.id());
+            // Best-effort fallback; ignore errors (process may have already exited).
             let _ = child.kill();
             // Reap the zombie; ignore the exit status.
             let _ = child.wait();
@@ -618,10 +627,20 @@ fn apply_lsp_env_scrub(cmd: &mut Command) {
 /// Extracted from `run_lsp_request` (crosslink #869) so the credential-
 /// stripping path lives in one place and `run_lsp_request` stays under
 /// the project's per-function line budget.
-fn spawn_language_server(server_cmd: &str, server_args: &[&str]) -> Result<Child, String> {
-    let mut cmd = Command::new(server_cmd);
-    cmd.args(server_args)
-        .stdin(Stdio::piped())
+fn spawn_language_server(
+    server_cmd: &str,
+    server_args: &[&str],
+    project_root: &Path,
+) -> Result<Child, String> {
+    let args: Vec<OsString> = server_args.iter().map(OsString::from).collect();
+    let mut cmd = crate::tools::sandboxed_process_command(
+        crate::tools::SandboxProfile::LanguageServer,
+        std::ffi::OsStr::new(server_cmd),
+        &args,
+        project_root,
+    )
+    .map_err(|error| format!("Failed to sandbox language server {server_cmd}: {error}"))?;
+    cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     apply_lsp_env_scrub(&mut cmd);
@@ -711,29 +730,6 @@ pub fn execute_lsp<S: BuildHasher>(args: &HashMap<String, Value, S>) -> (String,
             ),
             true,
         );
-    }
-
-    // 10 MiB file-size guard (#648): refuse to ship enormous buffers across
-    // the LSP wire — they reliably time out and starve the server of memory.
-    // Parity with CC `LSPTool.ts:53,264-269`.  We probe the size BEFORE
-    // canonicalising or reading the file so the failure mode is "cheap and
-    // honest" rather than "OOM the proxy".
-    //
-    // `metadata()` can fail for legitimate reasons (e.g. permission denied
-    // on a symlink target); we tolerate those and let `run_lsp_request`
-    // surface the canonical error rather than masking it here.
-    if let Ok(meta) = std::fs::metadata(file_path) {
-        if meta.len() > LSP_MAX_FILE_SIZE {
-            return (
-                format!(
-                    "File too large for LSP analysis: {} bytes exceeds the {}-byte limit \
-                     (10 MiB).  Trim the file or use grep/Read on a focused range.",
-                    meta.len(),
-                    LSP_MAX_FILE_SIZE
-                ),
-                true,
-            );
-        }
     }
 
     // crosslink #645: workspace/symbol takes a `query` string instead of a
@@ -934,20 +930,37 @@ fn run_lsp_request(
     // stringify only at this boundary because `run_lsp_request` returns
     // `Result<_, String>` to its caller; the rendered message now always
     // names the offending file.
-    let abs_path = std::fs::canonicalize(file_path)
-        .map_err(crate::file_error::FileError::with_path(file_path))
-        .map_err(|e| e.to_string())?;
-    let root_uri = find_project_root(&abs_path);
+    let (abs_path, file) = crate::tools::open_capability_regular_read(file_path)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("Cannot inspect confined LSP input '{file_path}': {error}"))?;
+    if metadata.len() > LSP_MAX_FILE_SIZE {
+        return Err(format!(
+            "File too large for LSP analysis: {} bytes exceeds the {}-byte limit (10 MiB)",
+            metadata.len(),
+            LSP_MAX_FILE_SIZE
+        ));
+    }
+    let security = crate::tools::security::current_context()?;
+    let root_uri = format!("file://{}", security.project_root().display());
     let file_uri = format!("file://{}", abs_path.display());
 
-    // Read file content for textDocument/didOpen
-    let content = crate::file_error::read_file(&abs_path).map_err(|e| e.to_string())?;
+    // Read from the already-confined descriptor. Reopening `abs_path` here
+    // would reintroduce a validation/open race.
+    let mut content = String::new();
+    file.take(LSP_MAX_FILE_SIZE + 1)
+        .read_to_string(&mut content)
+        .map_err(|error| format!("Cannot read confined LSP input '{file_path}': {error}"))?;
 
     // Spawn the server.  stderr is captured into a ring buffer (last 1 KiB) so
     // that crash diagnostics survive instead of being silently discarded
     // (original: Stdio::null() — fix #355 point 5). Env is scrubbed inside
     // `spawn_language_server` (crosslink #869).
-    let mut raw_child = spawn_language_server(server_cmd, server_args)?;
+    let project_root = root_uri
+        .strip_prefix("file://")
+        .map(Path::new)
+        .ok_or_else(|| format!("Invalid LSP root URI: {root_uri}"))?;
+    let mut raw_child = spawn_language_server(server_cmd, server_args, project_root)?;
 
     // Take pipes before handing the child to the guard.
     let mut stdin = raw_child.stdin.take().ok_or("Failed to get stdin")?;
@@ -1306,6 +1319,7 @@ fn write_lsp_raw(writer: &mut impl Write, msg: &Value) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(test)]
 fn find_project_root(file_path: &Path) -> String {
     let mut dir = file_path.parent().unwrap_or(file_path);
     loop {
@@ -1598,10 +1612,13 @@ fn filter_gitignored(locations: Vec<LspLocation>) -> Vec<LspLocation> {
     // ignored; 1 = none ignored; 128 = error (not a repo etc).
     let input = format!("{}\n", path_strings.join("\n"));
     let output = match git_bin().and_then(|git| {
-        crate::tools::command::run_with_timeout_with_input(
+        let project_root = crate::tools::security::current_context()?
+            .working_directory()
+            .to_path_buf();
+        crate::tools::command::run_sandboxed_with_timeout_with_input(
             git,
             &["check-ignore", "--stdin"],
-            None,
+            &project_root,
             LSP_GITIGNORE_TIMEOUT,
             input.as_bytes(),
         )
@@ -1849,7 +1866,10 @@ mod tests {
 
     #[test]
     fn child_guard_missing_child_returns_error_not_panic() {
-        let mut guard = ChildGuard { child: None };
+        let mut guard = ChildGuard {
+            child: None,
+            _registration: None,
+        };
         let err = guard
             .child_mut()
             .expect_err("missing child handle should be a normal LSP error");
@@ -2993,7 +3013,10 @@ mod tests {
     #[test]
     fn fix648_oversized_file_is_rejected_before_server_spawn() {
         use std::io::Write as _;
-        let tmp = tempfile::NamedTempFile::with_suffix(".rs").expect("tempfile");
+        let tmp = tempfile::Builder::new()
+            .suffix(".rs")
+            .tempfile_in(".")
+            .expect("project-local tempfile");
         // Write 10 MiB + 1 byte so we strictly exceed the limit.
         let payload = vec![b'a'; usize::try_from(LSP_MAX_FILE_SIZE).unwrap() + 1];
         {
@@ -3038,7 +3061,10 @@ mod tests {
     #[test]
     fn fix648_file_at_limit_is_not_rejected_by_size_guard() {
         use std::io::Write as _;
-        let tmp = tempfile::NamedTempFile::with_suffix(".rs").expect("tempfile");
+        let tmp = tempfile::Builder::new()
+            .suffix(".rs")
+            .tempfile_in(".")
+            .expect("project-local tempfile");
         let payload = vec![b'a'; usize::try_from(LSP_MAX_FILE_SIZE).unwrap()];
         {
             let mut f = std::fs::File::create(tmp.path()).expect("create");
@@ -3154,6 +3180,41 @@ mod tests {
                 "#869: {key} must be on the LSP env allowlist"
             );
         }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn language_server_profile_cannot_read_host_or_create_socket() {
+        let outside = tempfile::NamedTempFile::new().expect("host sentinel");
+        std::fs::write(outside.path(), "lsp-secret").expect("sentinel");
+        let marker_dir = tempfile::tempdir_in(".").expect("project marker directory");
+        let marker = marker_dir.path().join("result");
+        let script = format!(
+            r#"
+import errno, pathlib, socket
+outside = pathlib.Path({outside:?})
+marker = pathlib.Path({marker:?})
+file_blocked = not outside.exists()
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    network_blocked = False
+except OSError as error:
+    network_blocked = error.errno in (errno.EPERM, errno.EACCES)
+marker.write_text("confined" if file_blocked and network_blocked else "escaped")
+"#,
+            outside = outside.path().to_string_lossy(),
+            marker = marker.to_string_lossy(),
+        );
+        let security = crate::tools::security::current_context().expect("security context");
+        let mut child =
+            spawn_language_server("python3", &["-c", &script], security.working_directory())
+                .expect("sandboxed language server");
+        let status = child.wait().expect("language server probe");
+        assert!(status.success());
+        assert_eq!(
+            std::fs::read_to_string(&marker).expect("marker"),
+            "confined"
+        );
     }
 
     /// #869 — Sensitive credentials never reach the language server.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod args;
 mod ask_user;
 mod bash;
 pub(crate) use bash::record_command_observation_for_session;
+pub use bash::sandbox::{sandbox_diagnostics, sandbox_preflight, SandboxDiagnostics};
+pub(crate) use bash::sandbox::{sandboxed_hook_command, sandboxed_process_command, SandboxProfile};
 pub(crate) mod command;
 mod cron;
 pub(crate) mod crosslink;
@@ -27,7 +29,9 @@ pub(crate) mod crosslink;
 /// reach these via the module path.
 pub use cron::{execute_cron_create, execute_cron_delete, execute_cron_list};
 mod file;
+pub(crate) use file::open_capability_regular_read;
 mod grounding;
+pub mod security;
 /// Re-export the notebook-source-to-line-array helper so the
 /// E2E test suite (`tests/notebook_edit_e2e.rs`) can construct
 /// nbformat-compatible test fixtures without re-implementing
@@ -84,6 +88,13 @@ pub use bash::{
     check_command_against_global as check_bash_path_against_global, clear_global_path_constraints,
     install_global_path_constraints, PathConstraints,
 };
+pub(crate) use bash::{terminate_process_tree, terminate_session_background_jobs};
+pub(crate) use command::run_sandboxed_with_timeout_with_env;
+pub(crate) use command::{
+    cancel_all_sandbox_processes, cancel_session_sandbox_processes,
+    clear_session_process_cancellation,
+};
+pub(crate) use command::{run_prepared_sandboxed_with_timeout, CommandError};
 /// RAII guard that marks the current thread as executing inside a subagent
 /// task, so `execute_enter_plan_mode` refuses with the CC-parity error
 /// (crosslink #620). Subagent runners construct one of these for the
@@ -283,10 +294,40 @@ fn gate_or_legacy_result(
             target,
         } => Some(ToolResult {
             tool_call_id,
-            content: format!("PERMISSION_PROMPT: Allow {tool} on '{target}'? [y/n/a(lways)]"),
+            content: legacy_permission_prompt(&tool, &target),
             is_error: true,
         }),
     }
+}
+
+/// Describe the effective authority behind an interactive tool permission.
+///
+/// This is deliberately about the enforced boundary, not the command text:
+/// prompts must not imply that approving one string grants ambient host
+/// filesystem or network access.
+#[must_use]
+pub const fn permission_scope_summary(tool: &str) -> &'static str {
+    if tool.eq_ignore_ascii_case("bash") {
+        "project/explicit roots; controls masked; subprocess network denied"
+    } else if tool.eq_ignore_ascii_case("write")
+        || tool.eq_ignore_ascii_case("write_file")
+        || tool.eq_ignore_ascii_case("edit")
+        || tool.eq_ignore_ascii_case("edit_file")
+        || tool.eq_ignore_ascii_case("notebook_edit")
+    {
+        "named path within session write roots; control paths masked"
+    } else if tool.eq_ignore_ascii_case("webfetch") || tool.eq_ignore_ascii_case("web_fetch") {
+        "brokered URL only; redirects and resolved IPs pass SSRF policy"
+    } else {
+        "active session capabilities; no ambient host authority"
+    }
+}
+
+fn legacy_permission_prompt(tool: &str, target: &str) -> String {
+    format!(
+        "PERMISSION_PROMPT: Allow {tool} on '{target}'? [y/n/a(lways)]\nScope: {}",
+        permission_scope_summary(tool)
+    )
 }
 
 /// Execute a tool call with optional memory and permission manager.
@@ -336,6 +377,7 @@ fn execute_tool_with_memory_unchecked(
     }
 
     let mut ctx = ToolContext {
+        security: security::current_context(),
         memory_db,
         app_config: None,
         task_mgr: None,
@@ -403,6 +445,7 @@ fn execute_tool_full_unchecked(
         "task_stop" => subagent::execute_task_stop_tool(&args),
         _ => {
             let mut ctx = ToolContext {
+                security: security::current_context(),
                 memory_db,
                 app_config,
                 task_mgr: None,
@@ -677,7 +720,7 @@ pub fn check_tool_permission(
             target,
         } => Some(ToolResult {
             tool_call_id,
-            content: format!("PERMISSION_PROMPT: Allow {tool} on '{target}'? [y/n/a(lways)]"),
+            content: legacy_permission_prompt(&tool, &target),
             is_error: true,
         }),
     }
@@ -741,6 +784,7 @@ pub(crate) fn execute_tool_with_tasks_unchecked(
     // All other tools — including task_create/task_update/task_get/task_list —
     // go through the registry with the full context bundle.
     let mut ctx = ToolContext {
+        security: security::current_context(),
         memory_db,
         app_config,
         task_mgr,
@@ -781,7 +825,7 @@ pub fn execute_tool_with_permission_required(
         } => {
             return ToolResult {
                 tool_call_id,
-                content: format!("PERMISSION_PROMPT: Allow {tool} on '{target}'? [y/n/a(lways)]"),
+                content: legacy_permission_prompt(&tool, &target),
                 is_error: true,
             };
         }
@@ -1042,7 +1086,7 @@ mod tests {
     #[test]
     fn test_list_files() {
         let _cwd_lock = testutil::process_cwd_lock();
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = tempfile::tempdir_in(".").expect("tempdir");
         std::fs::write(
             dir.path().join("Cargo.toml"),
             "[package]\nname = \"fixture\"\n",
@@ -1372,7 +1416,7 @@ mod tests {
 
     #[test]
     fn test_read_notebook_file() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [
@@ -1415,7 +1459,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_replace() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [
@@ -1458,7 +1502,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_insert() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [
@@ -1503,7 +1547,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_delete() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [
@@ -1556,7 +1600,9 @@ mod tests {
         let mut args = HashMap::new();
         args.insert(
             "notebook_path".to_string(),
-            json!("/tmp/nonexistent_unread_notebook.ipynb"),
+            json!(std::env::current_dir()
+                .unwrap()
+                .join(".tmp-nonexistent-unread-notebook.ipynb")),
         );
         args.insert("cell_number".to_string(), json!(0));
         args.insert("new_source".to_string(), json!("test"));
@@ -1568,7 +1614,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_out_of_bounds() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [
@@ -1603,7 +1649,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_insert_requires_cell_type() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [],
@@ -1634,7 +1680,7 @@ mod tests {
 
     #[test]
     fn test_read_image_file() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let img_path = dir.path().join("test.png");
         // Write some fake PNG bytes
         let fake_png = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
@@ -1655,7 +1701,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_insert_code_cell_has_outputs() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("test.ipynb");
         let notebook = json!({
             "cells": [],
@@ -1699,7 +1745,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_resolves_by_cell_id() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("by-id.ipynb");
         let notebook = json!({
             "cells": [
@@ -1730,7 +1776,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_insert_after_cell_id() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("insert-after.ipynb");
         let notebook = json!({
             "cells": [
@@ -1766,7 +1812,7 @@ mod tests {
 
     #[test]
     fn test_notebook_edit_unknown_cell_id_errors() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir_in(".").unwrap();
         let nb_path = dir.path().join("unknown.ipynb");
         let notebook = json!({
             "cells": [

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -31,6 +31,8 @@ use serde_json::{json, Value};
 /// Bundles the three optional context objects that the old 3-function overload
 /// set threaded independently. Handlers that don't need a field ignore it.
 pub struct ToolContext<'a> {
+    /// Immutable filesystem/process capabilities for this session.
+    pub security: Result<std::sync::Arc<super::security::ToolSecurityContext>, String>,
     /// Optional archival memory database (stateful mode).
     pub memory_db: Option<&'a MemoryDb>,
     /// Optional application configuration (subagent tools).
@@ -127,6 +129,12 @@ impl ToolRegistry {
         args: &HashMap<String, Value>,
         ctx: &mut ToolContext<'_>,
     ) -> Option<(String, bool)> {
+        if let Err(error) = &ctx.security {
+            return Some((
+                format!("Tool execution is blocked because session capabilities are unavailable: {error}"),
+                true,
+            ));
+        }
         self.handlers.get(tool_name).map(|h| h.execute(args, ctx))
     }
 }

--- a/src/tools/security.rs
+++ b/src/tools/security.rs
@@ -1,0 +1,806 @@
+//! Immutable security capabilities for one agent/tool session.
+//!
+//! Security-sensitive tools must resolve paths and subprocess working
+//! directories from this context rather than ambient process state. Contexts
+//! are pinned on first use for a session and cannot later be replaced with a
+//! different project root.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
+
+const DEFAULT_SESSION_KEY: &str = "__default__";
+
+/// Filesystem capabilities pinned to one session.
+#[derive(Debug)]
+pub struct ToolSecurityContext {
+    session_id: String,
+    project_root: PathBuf,
+    working_directory: PathBuf,
+    private_temp: PrivateTempDir,
+    read_only_roots: Vec<PathBuf>,
+    read_write_roots: Vec<PathBuf>,
+    denied_paths: Vec<PathBuf>,
+    environment_grants: HashMap<String, String>,
+    network_policy: AgentNetworkPolicy,
+    #[cfg(unix)]
+    root_handles: Vec<CapabilityRootHandle>,
+}
+
+/// Network authority carried by an agent session.
+///
+/// Only the fail-closed default is currently implemented; unsupported grants
+/// are rejected during context creation rather than silently restoring the
+/// host namespace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentNetworkPolicy {
+    Denied,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct CapabilityRootHandle {
+    path: PathBuf,
+    writable: bool,
+    directory: std::fs::File,
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) struct LinuxBindRoot {
+    pub(crate) path: PathBuf,
+    pub(crate) writable: bool,
+    pub(crate) directory: std::os::fd::OwnedFd,
+}
+
+impl ToolSecurityContext {
+    fn new(
+        session_id: &str,
+        project_root: &Path,
+        working_directory: &Path,
+        read_only_roots: &[PathBuf],
+        read_write_roots: &[PathBuf],
+    ) -> Result<Self, String> {
+        let project_root = canonical_directory(project_root, "project root")?;
+        let working_directory = canonical_directory(working_directory, "working directory")?;
+        if !path_is_within(&working_directory, &project_root)
+            && !read_only_roots
+                .iter()
+                .chain(read_write_roots)
+                .any(|root| working_directory.starts_with(root))
+        {
+            return Err(format!(
+                "Working directory '{}' is outside the session project root '{}'",
+                working_directory.display(),
+                project_root.display()
+            ));
+        }
+        if is_unsafe_broad_root(&project_root) {
+            return Err(format!(
+                "Refusing to create an agent security context for broad project root '{}'",
+                project_root.display()
+            ));
+        }
+
+        let canonical_read_only = canonical_roots(read_only_roots, "read-only")?;
+        let mut canonical_read_write = canonical_roots(read_write_roots, "read-write")?;
+        if !canonical_read_write.contains(&project_root) {
+            canonical_read_write.push(project_root.clone());
+        }
+        let private_temp = PrivateTempDir::create()?;
+        canonical_read_write.push(private_temp.path().to_path_buf());
+        let denied_paths = restricted_project_paths(&project_root)?;
+        let environment_grants = startup_environment_grants()?;
+        let network_policy = startup_network_policy()?;
+        #[cfg(unix)]
+        let root_handles = open_capability_roots(&canonical_read_only, &canonical_read_write)?;
+
+        Ok(Self {
+            session_id: session_id.to_string(),
+            project_root,
+            working_directory,
+            private_temp,
+            read_only_roots: canonical_read_only,
+            read_write_roots: canonical_read_write,
+            denied_paths,
+            environment_grants,
+            network_policy,
+            #[cfg(unix)]
+            root_handles,
+        })
+    }
+
+    /// Session identifier that owns these capabilities.
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Canonical immutable project root.
+    #[must_use]
+    pub fn project_root(&self) -> &Path {
+        &self.project_root
+    }
+
+    /// Canonical immutable working directory.
+    #[must_use]
+    pub fn working_directory(&self) -> &Path {
+        &self.working_directory
+    }
+
+    /// Private temporary directory granted only to this session.
+    #[must_use]
+    pub fn private_temp_root(&self) -> &Path {
+        self.private_temp.path()
+    }
+
+    /// Whether a canonical path is readable by this session.
+    #[must_use]
+    pub fn permits_read(&self, path: &Path) -> bool {
+        !self.is_denied_path(path)
+            && self
+                .read_write_roots
+                .iter()
+                .chain(&self.read_only_roots)
+                .any(|root| path_is_within(path, root))
+    }
+
+    /// Whether a canonical path is writable by this session.
+    #[must_use]
+    pub fn permits_write(&self, path: &Path) -> bool {
+        !self.is_denied_path(path)
+            && self
+                .read_write_roots
+                .iter()
+                .any(|root| path_is_within(path, root))
+    }
+
+    /// Canonical roots visible to diagnostic and sandbox profile builders.
+    #[must_use]
+    pub fn read_only_roots(&self) -> &[PathBuf] {
+        &self.read_only_roots
+    }
+
+    /// Canonical writable roots visible to diagnostic and sandbox builders.
+    #[must_use]
+    pub fn read_write_roots(&self) -> &[PathBuf] {
+        &self.read_write_roots
+    }
+
+    /// Project subtrees excluded from otherwise broad project capabilities.
+    #[must_use]
+    pub fn denied_paths(&self) -> &[PathBuf] {
+        &self.denied_paths
+    }
+
+    /// Exact host-approved environment values inherited by agent processes.
+    #[must_use]
+    pub const fn environment_grants(&self) -> &HashMap<String, String> {
+        &self.environment_grants
+    }
+
+    /// Immutable session network policy.
+    #[must_use]
+    pub const fn network_policy(&self) -> AgentNetworkPolicy {
+        self.network_policy
+    }
+
+    /// Whether a path names or descends from a masked control/secret subtree.
+    #[must_use]
+    pub fn is_denied_path(&self, path: &Path) -> bool {
+        self.denied_paths
+            .iter()
+            .any(|denied| path == denied || path.starts_with(denied))
+    }
+
+    /// Return the longest matching pre-opened Linux capability-root handle.
+    ///
+    /// Root descriptors are pinned when the session is created. File tools
+    /// must anchor authoritative lookups to these descriptors rather than
+    /// reopening a root by pathname after policy validation.
+    #[cfg(unix)]
+    pub(crate) fn root_handle_for(
+        &self,
+        path: &Path,
+        write: bool,
+    ) -> Result<(&Path, &std::fs::File), String> {
+        if self.is_denied_path(path) {
+            return Err(format!(
+                "Path '{}' is masked from agent filesystem capabilities",
+                path.display()
+            ));
+        }
+        self.root_handles
+            .iter()
+            .filter(|root| {
+                (!write || root.writable)
+                    && (path == root.path.as_path() || path.starts_with(&root.path))
+            })
+            .max_by_key(|root| root.path.components().count())
+            .map(|root| (root.path.as_path(), &root.directory))
+            .ok_or_else(|| {
+                let access = if write { "writable" } else { "readable" };
+                format!(
+                    "Path '{}' is outside the session's {access} capability roots",
+                    path.display()
+                )
+            })
+    }
+
+    /// Duplicate the pinned capability roots onto descriptors reserved above
+    /// the seccomp descriptor. The launcher clears `FD_CLOEXEC` only in the
+    /// forked child, so concurrent host spawns never inherit them.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn duplicate_linux_bind_roots(&self) -> Result<Vec<LinuxBindRoot>, String> {
+        use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+        let mut roots = Vec::with_capacity(self.root_handles.len());
+        for root in &self.root_handles {
+            let duplicated =
+                unsafe { libc::fcntl(root.directory.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 200) };
+            if duplicated < 0 {
+                return Err(format!(
+                    "Cannot duplicate pinned capability root for sandbox mounting: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+            roots.push(LinuxBindRoot {
+                path: root.path.clone(),
+                writable: root.writable,
+                // SAFETY: fcntl returned a fresh owned descriptor.
+                directory: unsafe { std::os::fd::OwnedFd::from_raw_fd(duplicated) },
+            });
+        }
+        Ok(roots)
+    }
+}
+
+fn restricted_project_paths(project_root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut denied = vec![
+        project_root.join(".openclaudia"),
+        project_root.join(".claude"),
+    ];
+    let Some(raw) = std::env::var_os("OPENCLAUDIA_PROJECT_SECRET_MASKS") else {
+        return Ok(denied);
+    };
+    let raw = raw.to_str().ok_or_else(|| {
+        "OPENCLAUDIA_PROJECT_SECRET_MASKS contains non-Unicode data; refusing to create session capabilities"
+            .to_string()
+    })?;
+    for entry in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+    {
+        let path = Path::new(entry);
+        if path.is_absolute()
+            || !path
+                .components()
+                .all(|component| matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(format!(
+                "Invalid project secret mask '{entry}': use a non-empty relative path without '.' or '..'"
+            ));
+        }
+        let path = project_root.join(path);
+        if !denied.contains(&path) {
+            denied.push(path);
+        }
+    }
+    Ok(denied)
+}
+
+fn startup_environment_grants() -> Result<HashMap<String, String>, String> {
+    let Some(raw) = std::env::var_os("OPENCLAUDIA_AGENT_ENV_GRANTS") else {
+        return Ok(HashMap::new());
+    };
+    let raw = raw.to_str().ok_or_else(|| {
+        "OPENCLAUDIA_AGENT_ENV_GRANTS contains non-Unicode data; refusing session startup"
+            .to_string()
+    })?;
+    let mut grants = HashMap::new();
+    for name in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        let mut chars = name.chars();
+        let valid = chars
+            .next()
+            .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+            && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric());
+        let upper = name.to_ascii_uppercase();
+        let reserved = matches!(
+            upper.as_str(),
+            "HOME"
+                | "PATH"
+                | "TMP"
+                | "TEMP"
+                | "TMPDIR"
+                | "SSH_AUTH_SOCK"
+                | "DBUS_SESSION_BUS_ADDRESS"
+                | "DISPLAY"
+                | "WAYLAND_DISPLAY"
+                | "XDG_RUNTIME_DIR"
+                | "LD_PRELOAD"
+                | "DYLD_INSERT_LIBRARIES"
+                | "GCONV_PATH"
+                | "GLIBC_TUNABLES"
+                | "LOCPATH"
+                | "NLSPATH"
+        ) || upper.starts_with("LD_")
+            || upper.starts_with("DYLD_")
+            || upper.starts_with("OPENCLAUDIA_");
+        if !valid || reserved {
+            return Err(format!(
+                "Invalid or policy-reserved agent environment grant '{name}'"
+            ));
+        }
+        if let Some(value) = std::env::var_os(name) {
+            let value = value.to_str().ok_or_else(|| {
+                format!("Granted environment variable '{name}' is not valid UTF-8")
+            })?;
+            grants.insert(name.to_string(), value.to_string());
+        }
+    }
+    Ok(grants)
+}
+
+fn startup_network_policy() -> Result<AgentNetworkPolicy, String> {
+    match std::env::var("OPENCLAUDIA_AGENT_NETWORK") {
+        Ok(value) if !value.trim().is_empty() && !value.eq_ignore_ascii_case("denied") => Err(
+            "Only OPENCLAUDIA_AGENT_NETWORK=denied is supported; loopback and destination grants require a broker and will not fall back to the host network"
+                .to_string(),
+        ),
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(AgentNetworkPolicy::Denied),
+        Err(std::env::VarError::NotUnicode(_)) => Err(
+            "OPENCLAUDIA_AGENT_NETWORK contains non-Unicode data; refusing session startup"
+                .to_string(),
+        ),
+    }
+}
+
+#[cfg(unix)]
+fn open_capability_roots(
+    read_only_roots: &[PathBuf],
+    read_write_roots: &[PathBuf],
+) -> Result<Vec<CapabilityRootHandle>, String> {
+    use std::ffi::CString;
+    use std::os::fd::FromRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let mut handles = Vec::with_capacity(read_only_roots.len() + read_write_roots.len());
+    for (path, writable) in read_only_roots
+        .iter()
+        .map(|path| (path, false))
+        .chain(read_write_roots.iter().map(|path| (path, true)))
+    {
+        let path_c = CString::new(path.as_os_str().as_bytes())
+            .map_err(|_| format!("Capability root contains NUL: '{}'", path.display()))?;
+        // SAFETY: `path_c` is stable and NUL-terminated. A successful call
+        // returns one uniquely owned descriptor.
+        #[cfg(target_os = "linux")]
+        let directory_flags = libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        #[cfg(not(target_os = "linux"))]
+        let directory_flags =
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        let fd = unsafe { libc::open(path_c.as_ptr(), directory_flags) };
+        if fd < 0 {
+            return Err(format!(
+                "Cannot pin capability root '{}': {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ));
+        }
+        // SAFETY: the successful `open` returned a new owned descriptor.
+        let directory = unsafe { std::fs::File::from_raw_fd(fd) };
+        handles.push(CapabilityRootHandle {
+            path: path.clone(),
+            writable,
+            directory,
+        });
+    }
+    Ok(handles)
+}
+
+#[derive(Debug)]
+struct PrivateTempDir {
+    path: PathBuf,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl PrivateTempDir {
+    fn create() -> Result<Self, String> {
+        let parent = std::env::temp_dir();
+        for _ in 0..16 {
+            let path = parent.join(format!("openclaudia-agent-{}", uuid::Uuid::new_v4()));
+            match std::fs::create_dir(&path) {
+                Ok(()) => {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt as _;
+                        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))
+                            .map_err(|error| {
+                                let _ = std::fs::remove_dir(&path);
+                                format!(
+                                    "Cannot secure private session temp directory '{}': {error}",
+                                    path.display()
+                                )
+                            })?;
+                    }
+                    let canonical = path.canonicalize().map_err(|error| {
+                        let _ = std::fs::remove_dir(&path);
+                        format!(
+                            "Cannot resolve private session temp directory '{}': {error}",
+                            path.display()
+                        )
+                    })?;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::MetadataExt as _;
+                        let metadata = std::fs::symlink_metadata(&canonical).map_err(|error| {
+                            let _ = std::fs::remove_dir(&canonical);
+                            format!(
+                                "Cannot pin private session temp identity '{}': {error}",
+                                canonical.display()
+                            )
+                        })?;
+                        return Ok(Self {
+                            path: canonical,
+                            device: metadata.dev(),
+                            inode: metadata.ino(),
+                        });
+                    }
+                    #[cfg(not(unix))]
+                    return Ok(Self { path: canonical });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(format!(
+                        "Cannot create private session temp directory below '{}': {error}",
+                        parent.display()
+                    ));
+                }
+            }
+        }
+        Err("Cannot allocate a unique private session temp directory".to_string())
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for PrivateTempDir {
+    fn drop(&mut self) {
+        let tombstone = self
+            .path
+            .with_file_name(format!(".openclaudia-cleanup-{}", uuid::Uuid::new_v4()));
+        if let Err(error) = std::fs::rename(&self.path, &tombstone) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    %error,
+                    "Failed to atomically detach private session temp directory for cleanup"
+                );
+            }
+            return;
+        }
+        match std::fs::symlink_metadata(&tombstone) {
+            Ok(metadata)
+                if metadata.file_type().is_dir()
+                    && !metadata.file_type().is_symlink()
+                    && private_temp_identity_matches(self, &metadata) =>
+            {
+                // `remove_dir_all` uses descriptor-relative, no-follow
+                // traversal on supported Unix platforms. The unpredictable
+                // tombstone name also prevents reuse of the original
+                // capability path while cleanup proceeds.
+                if let Err(error) = std::fs::remove_dir_all(&tombstone) {
+                    tracing::warn!(
+                        path = %tombstone.display(),
+                        %error,
+                        "Failed to remove private session temp directory"
+                    );
+                }
+            }
+            Ok(_) => {
+                tracing::error!(
+                    path = %tombstone.display(),
+                    "Private session temp root changed identity or type; refusing recursive cleanup"
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    %error,
+                    "Failed to inspect private session temp directory during cleanup"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn private_temp_identity_matches(temp: &PrivateTempDir, metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+    metadata.dev() == temp.device && metadata.ino() == temp.inode
+}
+
+#[cfg(not(unix))]
+const fn private_temp_identity_matches(
+    _temp: &PrivateTempDir,
+    _metadata: &std::fs::Metadata,
+) -> bool {
+    true
+}
+
+type ContextMap = HashMap<String, Result<Arc<ToolSecurityContext>, String>>;
+
+static SESSION_CONTEXTS: LazyLock<Mutex<ContextMap>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn contexts(operation: &'static str) -> Result<MutexGuard<'static, ContextMap>, String> {
+    SESSION_CONTEXTS.lock().map_err(|error| {
+        tracing::error!(operation, %error, "Tool security-context lock poisoned");
+        "Tool security contexts are unavailable because their lock is poisoned".to_string()
+    })
+}
+
+/// Pin a default context for `session_id`, using the current directory only at
+/// this explicit session-boundary call.
+pub(crate) fn ensure_session_context(session_id: &str) -> Result<Arc<ToolSecurityContext>, String> {
+    let existing = contexts("lookup")?.get(session_id).cloned();
+    if let Some(existing) = existing {
+        return existing;
+    }
+    let cwd = std::env::current_dir()
+        .map_err(|error| format!("Cannot resolve session working directory: {error}"))?;
+    let read_only = startup_root_grants("OPENCLAUDIA_AGENT_READ_ONLY_ROOTS")?;
+    let read_write = startup_root_grants("OPENCLAUDIA_AGENT_READ_WRITE_ROOTS")?;
+    register_session_context(session_id, &cwd, &cwd, &read_only, &read_write)
+}
+
+fn startup_root_grants(name: &str) -> Result<Vec<PathBuf>, String> {
+    let Some(raw) = std::env::var_os(name) else {
+        return Ok(Vec::new());
+    };
+    std::env::split_paths(&raw)
+        .map(|path| {
+            if path.as_os_str().is_empty() {
+                Err(format!("{name} contains an empty path"))
+            } else {
+                Ok(path)
+            }
+        })
+        .collect()
+}
+
+/// Register explicit immutable capabilities for a session.
+pub(crate) fn register_session_context(
+    session_id: &str,
+    project_root: &Path,
+    working_directory: &Path,
+    read_only_roots: &[PathBuf],
+    read_write_roots: &[PathBuf],
+) -> Result<Arc<ToolSecurityContext>, String> {
+    let mut map = contexts("register")?;
+    if let Some(existing) = map.get(session_id) {
+        let existing = existing.as_ref().map_err(Clone::clone)?;
+        let requested_root = project_root
+            .canonicalize()
+            .map_err(|error| format!("Cannot resolve requested project root: {error}"))?;
+        if existing.project_root() != requested_root {
+            return Err(format!(
+                "Session '{session_id}' is already pinned to project root '{}'; refusing replacement with '{}'",
+                existing.project_root().display(),
+                requested_root.display()
+            ));
+        }
+        return Ok(Arc::clone(existing));
+    }
+
+    let created = ToolSecurityContext::new(
+        session_id,
+        project_root,
+        working_directory,
+        read_only_roots,
+        read_write_roots,
+    )
+    .map(Arc::new);
+    if let Ok(context) = &created {
+        tracing::info!(
+            target: "openclaudia::sandbox",
+            event = "session_capabilities_registered",
+            session_id = context.session_id(),
+            read_only_roots = context.read_only_roots().len(),
+            read_write_roots = context.read_write_roots().len(),
+            denied_paths = context.denied_paths().len(),
+            environment_grants = context.environment_grants().len(),
+            network = "denied",
+            "Registered immutable agent session capabilities"
+        );
+    }
+    map.insert(session_id.to_string(), created.clone());
+    created
+}
+
+/// Resolve the context for the thread's active session.
+///
+/// # Errors
+///
+/// Returns an error when the session context cannot be initialized or the
+/// immutable capability registry is unavailable.
+pub fn current_context() -> Result<Arc<ToolSecurityContext>, String> {
+    let session_id = super::todo::current_session_key();
+    if session_id == DEFAULT_SESSION_KEY {
+        return ensure_session_context(DEFAULT_SESSION_KEY);
+    }
+    ensure_session_context(&session_id)
+}
+
+/// Validate an IDE/client buffer path against the active immutable
+/// capability without opening the file. Existing symlink components are
+/// rejected so a client cannot label an outside buffer as project-local.
+pub(crate) fn validate_client_buffer_path(path: &Path) -> Result<PathBuf, String> {
+    let context = current_context()?;
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        context.working_directory().join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                normalized.push(component.as_os_str());
+            }
+            std::path::Component::Normal(name) => normalized.push(name),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                return Err("IDE buffer path contains '..' traversal".to_string())
+            }
+        }
+    }
+    if !context.permits_read(&normalized) {
+        return Err("IDE buffer path is outside or masked from the session capability".to_string());
+    }
+    #[cfg(unix)]
+    {
+        let (root, _) = context.root_handle_for(&normalized, false)?;
+        let relative = normalized
+            .strip_prefix(root)
+            .map_err(|_| "IDE buffer path escaped its capability root".to_string())?;
+        let mut walked = root.to_path_buf();
+        for component in relative.components() {
+            let std::path::Component::Normal(name) = component else {
+                continue;
+            };
+            walked.push(name);
+            match std::fs::symlink_metadata(&walked) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err("IDE buffer path traverses a symbolic link".to_string())
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+                Err(error) => return Err(format!("Cannot inspect IDE buffer path: {error}")),
+            }
+        }
+        Ok(normalized)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = normalized;
+        Err(
+            "IDE buffer access is blocked because this platform lacks a handle-relative backend"
+                .to_string(),
+        )
+    }
+}
+
+/// Drop the registry's ownership at session end. The private temp directory is
+/// removed when no in-flight tool still holds the context.
+pub(crate) fn release_session_context(session_id: &str) {
+    match contexts("release") {
+        Ok(mut map) => {
+            map.remove(session_id);
+        }
+        Err(error) => {
+            tracing::error!(session_id, %error, "Failed to release tool security context");
+        }
+    }
+}
+
+fn canonical_roots(roots: &[PathBuf], kind: &str) -> Result<Vec<PathBuf>, String> {
+    let mut canonical = Vec::with_capacity(roots.len());
+    for root in roots {
+        let root = canonical_directory(root, kind)?;
+        if is_unsafe_broad_root(&root) {
+            return Err(format!(
+                "Refusing broad {kind} capability root '{}'",
+                root.display()
+            ));
+        }
+        if !canonical.contains(&root) {
+            canonical.push(root);
+        }
+    }
+    Ok(canonical)
+}
+
+fn canonical_directory(path: &Path, label: &str) -> Result<PathBuf, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|error| format!("Cannot resolve {label} '{}': {error}", path.display()))?;
+    if !canonical.is_dir() {
+        return Err(format!(
+            "{label} '{}' is not a directory",
+            canonical.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+fn path_is_within(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+fn is_unsafe_broad_root(path: &Path) -> bool {
+    #[cfg(unix)]
+    const BROAD_ROOTS: &[&str] = &[
+        "/", "/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib64", "/media", "/mnt", "/opt",
+        "/proc", "/root", "/run", "/sbin", "/srv", "/sys", "/tmp", "/usr", "/var",
+    ];
+    #[cfg(unix)]
+    if BROAD_ROOTS.iter().any(|root| path == Path::new(root)) {
+        return true;
+    }
+    #[cfg(windows)]
+    if path.parent().is_none() {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+pub(crate) fn clear_contexts_for_test() {
+    if let Ok(mut map) = SESSION_CONTEXTS.lock() {
+        map.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sessions_receive_distinct_private_temp_roots() {
+        clear_contexts_for_test();
+        let root = tempfile::tempdir().expect("project root");
+        let first = register_session_context("security-a", root.path(), root.path(), &[], &[])
+            .expect("first context");
+        let second = register_session_context("security-b", root.path(), root.path(), &[], &[])
+            .expect("second context");
+        assert_ne!(first.private_temp_root(), second.private_temp_root());
+        assert!(first.permits_write(first.private_temp_root()));
+        assert!(!first.permits_read(second.private_temp_root()));
+        release_session_context("security-a");
+        release_session_context("security-b");
+    }
+
+    #[test]
+    fn session_root_cannot_be_replaced() {
+        clear_contexts_for_test();
+        let first = tempfile::tempdir().expect("first root");
+        let second = tempfile::tempdir().expect("second root");
+        register_session_context("security-pinned", first.path(), first.path(), &[], &[])
+            .expect("register");
+        let error =
+            register_session_context("security-pinned", second.path(), second.path(), &[], &[])
+                .expect_err("replacement must fail");
+        assert!(error.contains("already pinned"));
+        release_session_context("security-pinned");
+    }
+}

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -100,6 +100,13 @@ impl SessionIdGuard {
     /// before (which is almost always `None`).
     pub fn set(id: impl Into<String>) -> Self {
         let id = id.into();
+        if let Err(error) = super::security::ensure_session_context(&id) {
+            tracing::error!(
+                session_id = %id,
+                %error,
+                "Failed to initialize immutable tool security context"
+            );
+        }
         let previous = CURRENT_SESSION_ID.with(|cell| cell.replace(Some(id)));
         Self { previous }
     }

--- a/src/tools/worktree.rs
+++ b/src/tools/worktree.rs
@@ -237,14 +237,17 @@ fn validate_branch_name(name: &str) -> Result<(), String> {
     }
 
     // Defer the remaining ref-format rules (foo.lock, @, a@{b, leading '/',
-    // empty path segments, etc.) to git itself. We pin the cwd to the system
-    // temp dir so this check never depends on being inside a git repo.
-    let tmp = std::env::temp_dir();
-    let output = crate::tools::command::run_with_timeout(
+    // empty path segments, etc.) to git itself. Although this invocation does
+    // not inspect a repository, its argument is model-controlled, so keep it
+    // inside the common subprocess boundary.
+    let security = crate::tools::security::current_context()?;
+    let output = crate::tools::run_sandboxed_with_timeout_with_env(
+        crate::tools::SandboxProfile::StaticAnalyzer,
         git_bin()?,
         &["check-ref-format", "--branch", name],
-        Some(tmp.as_path()),
+        security.working_directory(),
         std::time::Duration::from_secs(GIT_TIMEOUT_SECS),
+        &HashMap::new(),
     )
     .map_err(|err| match err {
         crate::tools::command::CommandError::SpawnFailed { source, .. } => {
@@ -291,11 +294,35 @@ fn git_in(cwd: &Path, args: &[&str]) -> Result<std::process::Output, String> {
     // one timeout/backoff implementation. The git-specific timeout
     // and argv-tail formatting are kept here so the caller-visible
     // error string is unchanged.
-    crate::tools::command::run_with_timeout(
+    let mut hardened_args = vec![
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "diff.external=",
+        "-c",
+        "core.pager=cat",
+        "-c",
+        "credential.helper=",
+        "-c",
+        "protocol.file.allow=never",
+        "-c",
+        "protocol.ext.allow=never",
+    ];
+    hardened_args.extend_from_slice(args);
+    let env = HashMap::from([
+        ("GIT_CONFIG_GLOBAL".to_string(), "/dev/null".to_string()),
+        ("GIT_CONFIG_NOSYSTEM".to_string(), "1".to_string()),
+        ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
+    ]);
+    crate::tools::run_sandboxed_with_timeout_with_env(
+        crate::tools::SandboxProfile::GitWorktree,
         git,
-        args,
-        Some(cwd),
+        &hardened_args,
+        cwd,
         std::time::Duration::from_secs(GIT_TIMEOUT_SECS),
+        &env,
     )
     .map_err(|err| match err {
         crate::tools::command::CommandError::SpawnFailed { source, .. } => {
@@ -345,9 +372,14 @@ pub fn execute_enter_worktree<S: std::hash::BuildHasher>(
         return (format!("Error: {e}"), true);
     }
 
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return (format!("Error: cannot read current directory: {e}"), true),
+    let cwd = match crate::tools::security::current_context() {
+        Ok(context) => context.working_directory().to_path_buf(),
+        Err(e) => {
+            return (
+                format!("Error: cannot resolve session working directory: {e}"),
+                true,
+            )
+        }
     };
 
     match git_in(&cwd, &["rev-parse", "--is-inside-work-tree"]) {
@@ -868,7 +900,15 @@ pub fn execute_exit_worktree<S: std::hash::BuildHasher>(
 /// git but does not mutate any state.
 #[must_use]
 pub fn execute_list_worktrees() -> (String, bool) {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd = match crate::tools::security::current_context() {
+        Ok(context) => context.working_directory().to_path_buf(),
+        Err(error) => {
+            return (
+                format!("Failed to resolve session working directory: {error}"),
+                true,
+            )
+        }
+    };
     let output = git_in(&cwd, &["worktree", "list", "--porcelain"]);
 
     match output {
@@ -1020,9 +1060,16 @@ mod tests {
     fn enter_worktree_outside_git_repo_is_error() {
         let _lock = cwd_lock();
         let tmp = tempfile::tempdir().expect("temp dir");
-        let original = std::env::current_dir().ok();
-
-        let _ = std::env::set_current_dir(tmp.path());
+        let session_id = "worktree-outside-repository";
+        crate::tools::security::register_session_context(
+            session_id,
+            tmp.path(),
+            tmp.path(),
+            &[],
+            &[],
+        )
+        .expect("register isolated test capability");
+        let _session = crate::tools::SessionIdGuard::set(session_id);
 
         let mut args = HashMap::new();
         args.insert(
@@ -1030,10 +1077,7 @@ mod tests {
             serde_json::Value::String("test-branch".to_string()),
         );
         let (msg, is_err) = execute_enter_worktree(&args);
-
-        if let Some(orig) = original {
-            let _ = std::env::set_current_dir(orig);
-        }
+        crate::tools::security::release_session_context(session_id);
 
         assert!(is_err, "must error outside a git repo");
         assert!(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3306,7 +3306,7 @@ impl App {
         };
         let area = frame.area();
         let dialog_width = area.width.min(70);
-        let dialog_height = 7u16;
+        let dialog_height = 8u16;
         let x = (area.width.saturating_sub(dialog_width)) / 2;
         let y = area.height.saturating_sub(dialog_height + 4);
         let dialog_area = Rect::new(x, y, dialog_width, dialog_height);
@@ -3326,6 +3326,13 @@ impl App {
             )),
             Line::from(Span::styled(
                 format!("  Args: {args_preview}"),
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(Span::styled(
+                format!(
+                    "  Scope: {}",
+                    crate::tools::permission_scope_summary(&perm.tool_name)
+                ),
                 Style::default().fg(Color::DarkGray),
             )),
             Line::from(""),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -998,7 +998,7 @@ impl WelcomeScreen {
                 Style::default().fg(PURPLE),
             )),
             Line::from(Span::styled(
-                format!("Model: {}", &self.model),
+                format!("Model: {}", self.model),
                 Style::default().fg(GOLD),
             )),
             Line::from(Span::styled(&self.working_dir, Style::default().fg(DIM))),

--- a/src/vdd/static_analysis.rs
+++ b/src/vdd/static_analysis.rs
@@ -4,8 +4,8 @@
 //! tools, and integration with the `crosslink` library for creating issues
 //! from VDD findings (library-backed, no subprocess).
 
-use std::process::Stdio;
 use std::time::Duration;
+use std::{ffi::OsString, path::Path};
 
 use serde::Serialize;
 
@@ -72,14 +72,41 @@ pub(crate) async fn run_shell_command(command: &str, timeout: Duration) -> Stati
             passed: false,
         };
     };
-    let result = tokio::time::timeout(
-        timeout,
-        tokio::process::Command::new(program)
-            .args(argv_rest)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output(),
-    )
+    let security = match crate::tools::security::current_context() {
+        Ok(security) => security,
+        Err(error) => {
+            return StaticAnalysisResult {
+                command: command.to_string(),
+                exit_code: -1,
+                stdout: String::new(),
+                stderr: format!("Cannot resolve static-analysis session context: {error}"),
+                passed: false,
+            };
+        }
+    };
+    let cwd = security.working_directory();
+    let args: Vec<OsString> = argv_rest.iter().map(OsString::from).collect();
+    let sandboxed = match crate::tools::sandboxed_process_command(
+        crate::tools::SandboxProfile::StaticAnalyzer,
+        Path::new(program).as_os_str(),
+        &args,
+        cwd,
+    ) {
+        Ok(command) => command,
+        Err(error) => {
+            return StaticAnalysisResult {
+                command: command.to_string(),
+                exit_code: -1,
+                stdout: String::new(),
+                stderr: format!("Static-analysis sandbox unavailable: {error}"),
+                passed: false,
+            };
+        }
+    };
+    let program_label = program.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        crate::tools::run_prepared_sandboxed_with_timeout(sandboxed, &program_label, timeout)
+    })
     .await;
 
     match result {
@@ -100,11 +127,11 @@ pub(crate) async fn run_shell_command(command: &str, timeout: Duration) -> Stati
             stderr: format!("Command failed to execute: {e}"),
             passed: false,
         },
-        Err(_) => StaticAnalysisResult {
+        Err(error) => StaticAnalysisResult {
             command: command.to_string(),
             exit_code: -1,
             stdout: String::new(),
-            stderr: format!("Command timed out after {}s", timeout.as_secs()),
+            stderr: format!("Static-analysis worker failed: {error}"),
             passed: false,
         },
     }
@@ -141,9 +168,10 @@ pub(crate) async fn create_crosslink_issue(
     let collapsed_comment = comment.replace('\n', " ");
 
     tokio::task::spawn_blocking(move || -> Result<String, VddError> {
-        let cwd = std::env::current_dir().map_err(|e| {
-            VddError::CrosslinkError(format!("Failed to read current directory: {e}"))
-        })?;
+        let cwd = crate::tools::security::current_context()
+            .map_err(VddError::CrosslinkError)?
+            .working_directory()
+            .to_path_buf();
         let dir = cwd.join(".crosslink");
         std::fs::create_dir_all(&dir)
             .map_err(|e| VddError::CrosslinkError(format!("Failed to create .crosslink/: {e}")))?;
@@ -188,5 +216,34 @@ mod tests {
         assert_eq!(result.exit_code, -1);
         assert!(result.stderr.contains("Could not parse command"));
         assert!(!result.passed);
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "linux")]
+    async fn analyzer_profile_blocks_host_files_and_network_syscalls() {
+        let outside = tempfile::NamedTempFile::new().expect("host sentinel");
+        std::fs::write(outside.path(), "analyzer-secret").expect("sentinel");
+        let script = format!(
+            r#"
+import errno, pathlib, socket
+path = pathlib.Path({path:?})
+file_blocked = not path.exists()
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    network_blocked = False
+except OSError as error:
+    network_blocked = error.errno in (errno.EPERM, errno.EACCES)
+print("analyzer_confined=" + str(file_blocked and network_blocked).lower())
+"#,
+            path = outside.path().to_string_lossy()
+        );
+        let command = format!(
+            "python3 -c {}",
+            shlex::try_quote(&script).expect("quote analyzer probe")
+        );
+        let result = run_shell_command(&command, Duration::from_secs(5)).await;
+        assert!(result.passed, "analyzer probe failed: {}", result.stderr);
+        assert!(result.stdout.contains("analyzer_confined=true"));
+        assert!(!result.stdout.contains("analyzer-secret"));
     }
 }

--- a/tests/ask_user_question_validation_e2e.rs
+++ b/tests/ask_user_question_validation_e2e.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 fn dispatch_ask_user(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/bash_dispatch_validation_e2e.rs
+++ b/tests/bash_dispatch_validation_e2e.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 
 fn dispatch_bash(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -30,6 +31,7 @@ fn dispatch_bash(args: &HashMap<String, Value>) -> (String, bool) {
 
 fn dispatch_bash_output(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/bash_integration.rs
+++ b/tests/bash_integration.rs
@@ -349,10 +349,13 @@ fn b2e_kill_shells_for_agent_terminates_only_matching_agent_shells() {
 
     std::thread::sleep(std::time::Duration::from_millis(100));
 
-    let result = execute_tool(&make_tool_call(
-        "kill_shells_for_agent",
-        &json!({ "agent_id": alpha }),
-    ));
+    let result = {
+        let _guard = SessionIdGuard::set(alpha);
+        execute_tool(&make_tool_call(
+            "kill_shells_for_agent",
+            &json!({ "agent_id": alpha }),
+        ))
+    };
     assert!(
         !result.is_error,
         "B2e: kill_shells_for_agent must succeed; got: {}",
@@ -366,39 +369,52 @@ fn b2e_kill_shells_for_agent_terminates_only_matching_agent_shells() {
         result.content
     );
 
-    let alpha_poll = execute_tool(&make_tool_call(
-        "bash_output",
-        &json!({ "shell_id": alpha_shell }),
-    ));
+    let alpha_poll = {
+        let _guard = SessionIdGuard::set(alpha);
+        execute_tool(&make_tool_call(
+            "bash_output",
+            &json!({ "shell_id": alpha_shell }),
+        ))
+    };
     assert!(
         alpha_poll.is_error,
         "B2e: killed alpha shell must be removed from lookup; got: {}",
         alpha_poll.content
     );
 
-    let beta_poll = execute_tool(&make_tool_call(
-        "bash_output",
-        &json!({ "shell_id": beta_shell }),
-    ));
+    let beta_poll = {
+        let _guard = SessionIdGuard::set(beta);
+        execute_tool(&make_tool_call(
+            "bash_output",
+            &json!({ "shell_id": beta_shell }),
+        ))
+    };
     assert!(
         !beta_poll.is_error,
         "B2e: beta shell must remain available after alpha cleanup; got: {}",
         beta_poll.content
     );
 
-    let _cleanup = execute_tool(&make_tool_call(
-        "kill_shell",
-        &json!({ "shell_id": beta_shell }),
-    ));
+    let _cleanup = {
+        let _guard = SessionIdGuard::set(beta);
+        execute_tool(&make_tool_call(
+            "kill_shell",
+            &json!({ "shell_id": beta_shell }),
+        ))
+    };
 }
 
 /// B2f — agent-scoped cleanup is idempotent when no shells match.
 #[test]
 fn b2f_kill_shells_for_agent_no_matches_succeeds() {
-    let result = execute_tool(&make_tool_call(
-        "kill_shells_for_agent",
-        &json!({ "agent_id": "gap584-agent-without-shells" }),
-    ));
+    let agent = "gap584-agent-without-shells";
+    let result = {
+        let _guard = SessionIdGuard::set(agent);
+        execute_tool(&make_tool_call(
+            "kill_shells_for_agent",
+            &json!({ "agent_id": agent }),
+        ))
+    };
     assert!(
         !result.is_error,
         "B2f: no-match cleanup must be idempotent success; got: {}",
@@ -888,9 +904,12 @@ fn b5l_denylist_blocks_proc_environ_reads() {
 #[test]
 #[cfg(unix)]
 fn b6a_cd_single_quoted_path_reaches_bash() {
-    use tempfile::TempDir;
-    let dir = TempDir::new().expect("B6a: tempdir");
-    let path = dir.path().to_string_lossy().into_owned();
+    let dir = tempfile::Builder::new()
+        .prefix("openclaudia-b6a-")
+        .tempdir_in(".")
+        .expect("B6a: project tempdir");
+    let canonical = dir.path().canonicalize().expect("B6a: canonical tempdir");
+    let path = canonical.to_string_lossy().into_owned();
 
     let result = execute_tool(&make_tool_call(
         "bash",
@@ -903,7 +922,7 @@ fn b6a_cd_single_quoted_path_reaches_bash() {
         result.content
     );
     assert!(
-        result.content.contains(dir.path().to_str().unwrap()),
+        result.content.contains(canonical.to_str().unwrap()),
         "B6a: pwd must show the target dir; got: {}",
         result.content
     );
@@ -946,9 +965,12 @@ fn b6b_cd_nonexistent_path_reaches_bash_not_oc_denylist() {
 #[test]
 #[cfg(unix)]
 fn b6c_cd_double_quoted_path_with_spaces_executes() {
-    use tempfile::TempDir;
-    let dir = TempDir::new().expect("B6c: tempdir");
-    let path = dir.path().to_string_lossy().into_owned();
+    let dir = tempfile::Builder::new()
+        .prefix("openclaudia b6c ")
+        .tempdir_in(".")
+        .expect("B6c: project tempdir");
+    let canonical = dir.path().canonicalize().expect("B6c: canonical tempdir");
+    let path = canonical.to_string_lossy().into_owned();
 
     let result = execute_tool(&make_tool_call(
         "bash",
@@ -961,30 +983,22 @@ fn b6c_cd_double_quoted_path_with_spaces_executes() {
         result.content
     );
     assert!(
-        result.content.contains(dir.path().to_str().unwrap()),
+        result.content.contains(canonical.to_str().unwrap()),
         "B6c: pwd must show the target dir; got: {}",
         result.content
     );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// B7 — Sandbox toggle: document OC's current behavior, mark missing
+// B7 — Sandbox containment
 // Spec: crosslink #526 §B7
-// OC source: src/tools/bash/mod.rs (no sandbox implementation)
-//
-// GAP: OC has NO sandbox. CC wraps execution in seccomp/firejail/macOS
-// sandbox-exec via SandboxManager. OC's only isolation is process_group(0)
-// (for clean SIGTERM delivery) and env scrubbing.
-// Ref crosslink #575 (sandbox missing).
+// OC source: src/tools/bash/sandbox.rs
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// B7a — OC accepts `dangerouslyDisableSandbox` field but ignores it
+/// B7a — model input cannot disable the OS sandbox
 ///
-/// CC: field is parsed and passed to `shouldUseSandbox()` (BashTool.tsx:241).
 /// OC: field is not in the input schema; unknown JSON args are silently ignored.
-/// Passing the field must not cause an error.
-///
-/// GAP: crosslink #575 — sandbox subsystem missing.
+/// Passing the field must not cause an error or alter containment.
 #[test]
 fn b7a_dangerously_disable_sandbox_ignored_no_error() {
     let result = execute_tool(&make_tool_call(
@@ -1026,15 +1040,14 @@ fn b7b_gap_573_powershell_tool_not_registered() {
     );
 }
 
-/// B7c — GAP: commands run unsandboxed (filesystem writes succeed)
+/// B7c — host filesystem writes are contained
 ///
-/// OC: `process_group(0)` is NOT a security sandbox — it exists only for
-/// clean SIGTERM delivery. Ref crosslink #575.
-///
-/// Pin: a command with filesystem side-effects succeeds, proving no sandbox blocks it.
+/// A model can spell the destination through an interpreter, expansion, or a
+/// symlink, so this assertion tests the OS boundary rather than the command
+/// parser.
 #[test]
-#[cfg(unix)]
-fn b7c_gap_575_commands_run_without_sandbox() {
+#[cfg(target_os = "linux")]
+fn b7c_host_filesystem_write_is_blocked() {
     use tempfile::TempDir;
     let dir = TempDir::new().expect("B7c: tempdir");
     let file_path = dir.path().join("sandbox_probe.txt");
@@ -1042,18 +1055,154 @@ fn b7c_gap_575_commands_run_without_sandbox() {
 
     let result = execute_tool(&make_tool_call(
         "bash",
-        &json!({ "command": format!("echo unsandboxed > '{path_str}'") }),
+        &json!({
+            "command": format!(
+                "python3 -c 'from pathlib import Path; Path({path_str:?}).write_text(\"escaped\")'"
+            )
+        }),
     ));
 
-    // If OC were sandboxed, the write would be blocked; it must succeed.
     assert!(
-        !result.is_error,
-        "B7c: unsandboxed write must succeed (gap #575); got: {}",
+        result.is_error,
+        "B7c: writing a host temp path must fail; got: {}",
+        result.content,
+    );
+    assert!(!file_path.exists(), "B7c: host file escaped the sandbox");
+}
+
+/// B7d — symlinks cannot turn an in-project path into host access.
+#[test]
+#[cfg(target_os = "linux")]
+fn b7d_symlink_to_host_file_is_blocked() {
+    use std::os::unix::fs::symlink;
+
+    let host_dir = tempfile::TempDir::new().expect("B7d: host tempdir");
+    let host_secret = host_dir.path().join("secret.txt");
+    std::fs::write(&host_secret, "B7D_HOST_SECRET").expect("B7d: write host secret");
+
+    let project_dir = tempfile::Builder::new()
+        .prefix("openclaudia-b7d-")
+        .tempdir_in(".")
+        .expect("B7d: project tempdir");
+    let link = project_dir.path().join("outside-link");
+    symlink(&host_secret, &link).expect("B7d: create symlink");
+    let link = link.canonicalize().unwrap_or(link);
+    let link_path = project_dir.path().join("outside-link");
+
+    let result = execute_tool(&make_tool_call(
+        "bash",
+        &json!({ "command": format!("cat -- {:?}", link_path.to_string_lossy()) }),
+    ));
+
+    assert!(result.is_error, "B7d: symlink read must fail: {result:?}");
+    assert!(
+        !result.content.contains("B7D_HOST_SECRET"),
+        "B7d: host secret crossed the sandbox: {} (target {})",
+        result.content,
+        link.display(),
+    );
+}
+
+/// B7e — the sandbox has no route to a listening host TCP socket.
+#[test]
+#[cfg(target_os = "linux")]
+fn b7e_host_network_is_unreachable() {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("B7e: bind listener");
+    let port = listener.local_addr().expect("B7e: local address").port();
+
+    let result = execute_tool(&make_tool_call(
+        "bash",
+        &json!({
+            "command": format!(
+                "python3 -c 'import socket; socket.create_connection((\"127.0.0.1\", {port}), .2)'"
+            )
+        }),
+    ));
+
+    assert!(
+        result.is_error,
+        "B7e: sandbox connected to a host socket: {}",
         result.content
     );
+    listener
+        .set_nonblocking(true)
+        .expect("B7e: nonblocking listener");
     assert!(
-        file_path.exists(),
-        "B7c: file must be written — no sandbox blocking writes (gap #575)"
+        matches!(
+            listener.accept(),
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock
+        ),
+        "B7e: host listener accepted a sandbox connection"
+    );
+}
+
+/// B7f — project output remains writable, but harness and VCS control state do not.
+#[test]
+#[cfg(target_os = "linux")]
+fn b7f_project_is_writable_but_control_state_is_protected() {
+    let project_dir = tempfile::Builder::new()
+        .prefix("openclaudia-b7f-")
+        .tempdir_in(".")
+        .expect("B7f: project tempdir");
+    let output = project_dir.path().join("output.txt");
+    let output_path = output
+        .canonicalize()
+        .unwrap_or_else(|_| output.clone())
+        .to_string_lossy()
+        .into_owned();
+
+    let write = execute_tool(&make_tool_call(
+        "bash",
+        &json!({ "command": format!("printf sandboxed > {output_path:?}") }),
+    ));
+    assert!(!write.is_error, "B7f: project write failed: {write:?}");
+    assert_eq!(
+        std::fs::read_to_string(&output).expect("B7f: read project output"),
+        "sandboxed"
+    );
+
+    let git_probe = std::path::Path::new(".git/openclaudia-sandbox-probe");
+    assert!(!git_probe.exists(), "B7f: stale git probe");
+    let control_write = execute_tool(&make_tool_call(
+        "bash",
+        &json!({ "command": "touch .git/openclaudia-sandbox-probe" }),
+    ));
+    assert!(
+        control_write.is_error,
+        "B7f: .git write escaped protection: {control_write:?}"
+    );
+    assert!(!git_probe.exists(), "B7f: sandbox mutated .git");
+
+    let git_status = execute_tool(&make_tool_call(
+        "bash",
+        &json!({ "command": "git status --short >/dev/null" }),
+    ));
+    assert!(
+        !git_status.is_error,
+        "B7f: read-only git workflow failed: {git_status:?}"
+    );
+
+    let hidden_state = execute_tool(&make_tool_call(
+        "bash",
+        &json!({ "command": "test ! -e .openclaudia/memory.db && test ! -e .claude/hooks" }),
+    ));
+    assert!(
+        !hidden_state.is_error,
+        "B7f: harness control state is visible: {hidden_state:?}"
+    );
+}
+
+/// B7g — a process in the sandbox cannot create a nested user namespace.
+#[test]
+#[cfg(target_os = "linux")]
+fn b7g_nested_user_namespace_is_blocked() {
+    let result = execute_tool(&make_tool_call(
+        "bash",
+        &json!({ "command": "unshare -Ur --map-root-user true" }),
+    ));
+    assert!(
+        result.is_error,
+        "B7g: nested user namespace unexpectedly succeeded: {result:?}"
     );
 }
 

--- a/tests/bash_output_kill_dispatch_e2e.rs
+++ b/tests/bash_output_kill_dispatch_e2e.rs
@@ -12,11 +12,13 @@
 #![allow(clippy::unwrap_used)]
 
 use openclaudia::tools::registry::{registry, ToolContext};
+use openclaudia::tools::SessionIdGuard;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
 fn dispatch_bash_output(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -28,6 +30,7 @@ fn dispatch_bash_output(args: &HashMap<String, Value>) -> (String, bool) {
 
 fn dispatch_kill_shell(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -39,6 +42,7 @@ fn dispatch_kill_shell(args: &HashMap<String, Value>) -> (String, bool) {
 
 fn dispatch_kill_shells_for_agent(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -199,13 +203,24 @@ fn kill_shells_for_agent_with_empty_agent_id_treated_as_missing() {
 
 #[test]
 fn kill_shells_for_agent_with_unknown_agent_id_is_idempotent_success() {
-    let args = args_with(&[("agent_id", json!("no-shells-for-this-agent"))]);
+    let owner = "no-shells-for-this-agent";
+    let _guard = SessionIdGuard::set(owner);
+    let args = args_with(&[("agent_id", json!(owner))]);
     let (msg, is_err) = dispatch_kill_shells_for_agent(&args);
     assert!(!is_err);
     assert!(
         msg.contains("No background shells found"),
         "unknown agent cleanup should be idempotent; got {msg:?}"
     );
+}
+
+#[test]
+fn kill_shells_for_agent_rejects_cross_session_cleanup() {
+    let _guard = SessionIdGuard::set("caller-session");
+    let args = args_with(&[("agent_id", json!("different-session"))]);
+    let (msg, is_err) = dispatch_kill_shells_for_agent(&args);
+    assert!(is_err);
+    assert!(msg.contains("another session"));
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/tests/cron_dispatch_validation_e2e.rs
+++ b/tests/cron_dispatch_validation_e2e.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::unwrap_used)]
 
 use openclaudia::tools::registry::{registry, ToolContext};
+use openclaudia::tools::SessionIdGuard;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -27,16 +28,24 @@ fn cwd_lock() -> MutexGuard<'static, ()> {
 }
 
 fn run_in_tempdir<R>(f: impl FnOnce() -> R) -> R {
+    struct RestoreCwd(std::path::PathBuf);
+    impl Drop for RestoreCwd {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
     let prev = std::env::current_dir().expect("cwd");
     let tmp = TempDir::new().expect("tempdir");
     std::env::set_current_dir(tmp.path()).expect("set cwd");
-    let outcome = f();
-    std::env::set_current_dir(&prev).expect("restore cwd");
-    outcome
+    let _restore = RestoreCwd(prev);
+    let _session = SessionIdGuard::set(format!("cron-dispatch-{}", tmp.path().display()));
+    f()
 }
 
 fn dispatch(name: &str, args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/cron_e2e.rs
+++ b/tests/cron_e2e.rs
@@ -24,7 +24,9 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 
-use openclaudia::tools::{execute_cron_create, execute_cron_delete, execute_cron_list};
+use openclaudia::tools::{
+    execute_cron_create, execute_cron_delete, execute_cron_list, SessionIdGuard,
+};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -57,13 +59,18 @@ fn cwd_lock() -> MutexGuard<'static, ()> {
 /// helper MUST run single-threaded (`--test-threads=1`).
 struct CwdGuard {
     prev: PathBuf,
+    _session: SessionIdGuard,
 }
 
 impl CwdGuard {
     fn set_to(path: &std::path::Path) -> Self {
         let prev = std::env::current_dir().expect("current_dir");
         std::env::set_current_dir(path).expect("set_current_dir");
-        Self { prev }
+        let session = SessionIdGuard::set(format!("cron-e2e-{}", path.display()));
+        Self {
+            prev,
+            _session: session,
+        }
     }
 }
 

--- a/tests/cron_schedule_shape_e2e.rs
+++ b/tests/cron_schedule_shape_e2e.rs
@@ -13,7 +13,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 
-use openclaudia::tools::{execute_cron_create, execute_cron_list};
+use openclaudia::tools::{execute_cron_create, execute_cron_list, SessionIdGuard};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -31,13 +31,20 @@ fn cwd_lock() -> MutexGuard<'static, ()> {
 }
 
 fn run_in_tempdir<R>(f: impl FnOnce() -> R) -> R {
+    struct RestoreCwd(std::path::PathBuf);
+    impl Drop for RestoreCwd {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
     let prev = std::env::current_dir().expect("current_dir");
     let tmp = TempDir::new().expect("tempdir");
     std::env::set_current_dir(tmp.path()).expect("set cwd");
+    let _restore = RestoreCwd(prev);
+    let _session = SessionIdGuard::set(format!("cron-shape-{}", tmp.path().display()));
     std::fs::create_dir_all(".openclaudia").expect("mkdir");
-    let outcome = f();
-    std::env::set_current_dir(&prev).expect("restore cwd");
-    outcome
+    f()
 }
 
 fn cron_args(name: &str, schedule: &str, prompt: &str) -> HashMap<String, Value> {

--- a/tests/crosslink_dispatch_validation_e2e.rs
+++ b/tests/crosslink_dispatch_validation_e2e.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 
 fn dispatch(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/edit_file_dispatch_validation_e2e.rs
+++ b/tests/edit_file_dispatch_validation_e2e.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex};
 
 fn dispatch_edit(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -32,6 +33,7 @@ fn dispatch_edit(args: &HashMap<String, Value>) -> (String, bool) {
 
 fn dispatch_read(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -106,7 +108,7 @@ fn path_with_parent_dir_traversal_rejected_pre_read_gate() {
 #[test]
 fn edit_existing_file_without_prior_read_errors_with_documented_message() {
     // Create a file that has NOT been read via read_file.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("never_read_unique.txt");
     std::fs::write(&path, "original body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -138,7 +140,7 @@ fn edit_existing_file_without_prior_read_errors_with_documented_message() {
 #[test]
 fn failed_read_does_not_satisfy_edit_gate() {
     let _session_guard = SessionIdGuard::set("failed-read-edit-gate");
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("empty.png");
     std::fs::write(&path, "").expect("create empty image");
     let path_str = path.to_str().expect("utf8 path");
@@ -168,7 +170,7 @@ fn failed_read_does_not_satisfy_edit_gate() {
 
 #[test]
 fn edit_after_explicit_read_file_dispatch_passes_must_read_gate() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("read_then_edited_unique.txt");
     std::fs::write(&path, "before").expect("create");
     let path_str = path.to_str().unwrap();
@@ -199,7 +201,7 @@ fn edit_records_diff_and_stales_prior_read_observation() {
     let _ledger_guard =
         openclaudia::ledger::install_active_ledger_for_session("editledger", Arc::clone(&ledger));
 
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("ledger_edit.txt");
     std::fs::write(&path, "before\n").expect("create");
     let path_str = path.to_str().unwrap();
@@ -256,7 +258,7 @@ fn edit_records_diff_and_stales_prior_read_observation() {
 
 #[test]
 fn missing_old_string_after_read_errors() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("missing_old.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -275,7 +277,7 @@ fn missing_old_string_after_read_errors() {
 
 #[test]
 fn missing_new_string_after_read_errors() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("missing_new.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -293,7 +295,7 @@ fn missing_new_string_after_read_errors() {
 
 #[test]
 fn old_string_arg_as_number_after_read_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("wrong_old.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -312,7 +314,7 @@ fn old_string_arg_as_number_after_read_returns_validation_error() {
 
 #[test]
 fn new_string_arg_as_number_after_read_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("wrong_new.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -335,7 +337,7 @@ fn new_string_arg_as_number_after_read_returns_validation_error() {
 
 #[test]
 fn no_op_edit_with_identical_old_and_new_strings_refused() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("noop.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -358,7 +360,7 @@ fn no_op_edit_with_identical_old_and_new_strings_refused() {
 #[test]
 fn no_op_edit_with_empty_strings_refused() {
     // PINS #970: empty == empty is also a no-op.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("noop_empty.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -377,7 +379,7 @@ fn no_op_edit_with_empty_strings_refused() {
 #[test]
 fn no_op_does_not_modify_file_mtime() {
     // PINS #970 DOC: no-op fails BEFORE any I/O.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("noop_mtime.txt");
     std::fs::write(&path, "body").expect("create");
     let path_str = path.to_str().unwrap();
@@ -407,7 +409,7 @@ fn multi_occurrence_without_replace_all_refused() {
     // PINS #687: when replace_all=false (default), multiple
     // occurrences MUST be rejected so callers provide
     // uniquely-matching context.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("multi_occur.txt");
     std::fs::write(&path, "x\nx\nx\n").expect("create");
     let path_str = path.to_str().unwrap();
@@ -429,7 +431,7 @@ fn multi_occurrence_without_replace_all_refused() {
 
 #[test]
 fn multi_occurrence_with_replace_all_true_succeeds() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("multi_replace_all.txt");
     std::fs::write(&path, "x\nx\nx\n").expect("create");
     let path_str = path.to_str().unwrap();
@@ -451,7 +453,7 @@ fn multi_occurrence_with_replace_all_true_succeeds() {
 
 #[test]
 fn replace_all_false_explicit_matches_default_behavior() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("replace_explicit_false.txt");
     std::fs::write(&path, "a\na\n").expect("create");
     let path_str = path.to_str().unwrap();
@@ -477,7 +479,7 @@ fn replace_all_false_explicit_matches_default_behavior() {
 
 #[test]
 fn single_occurrence_edit_replaces_byte_exact() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("single_occur.txt");
     std::fs::write(&path, "before content\nafter\n").expect("create");
     let path_str = path.to_str().unwrap();
@@ -498,7 +500,7 @@ fn single_occurrence_edit_replaces_byte_exact() {
 
 #[test]
 fn unicode_old_and_new_strings_round_trip() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("unicode_edit.txt");
     std::fs::write(&path, "before 日本語 content\n").expect("create");
     let path_str = path.to_str().unwrap();

--- a/tests/execute_tool_envelope_e2e.rs
+++ b/tests/execute_tool_envelope_e2e.rs
@@ -69,7 +69,7 @@ fn execute_tool_result_has_owned_string_fields() {
 
 #[test]
 fn execute_tool_dispatches_list_files() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let tc = call(
         "c1",
         "list_files",
@@ -240,7 +240,7 @@ fn execute_tool_unknown_tool_is_deterministic_across_5_calls() {
 
 #[test]
 fn execute_tool_with_same_args_yields_same_envelope_for_list_files() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let tc = call(
         "c1",
         "list_files",

--- a/tests/file_search_e2e.rs
+++ b/tests/file_search_e2e.rs
@@ -71,7 +71,7 @@ fn touch(path: &Path, content: &str) {
 
 #[test]
 fn list_files_returns_top_level_entries_of_tempdir() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let root = dir.path();
     touch(&root.join("alpha.rs"), "");
     touch(&root.join("bravo.md"), "");
@@ -108,7 +108,7 @@ fn list_files_default_path_is_cwd() {
 
 #[test]
 fn list_files_nonexistent_path_errors() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let nonexistent = dir.path().join("never-existed");
     let (msg, is_err) = list_files(&json!({
         "path": nonexistent.to_string_lossy().to_string(),
@@ -122,7 +122,7 @@ fn list_files_nonexistent_path_errors() {
 
 #[test]
 fn glob_matches_pattern_across_nested_dirs() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let root = dir.path();
     touch(&root.join("top.rs"), "");
     touch(&root.join("src/main.rs"), "");
@@ -167,7 +167,7 @@ fn glob_allow_hidden_root_disables_skip_list() {
     // root on Linux is `/tmp/.tmpXXX/...` — so the hidden-root
     // heuristic ALWAYS fires under tempfile. Pinning the
     // alternate behaviour instead is the honest test.)
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let root = dir.path();
     let root_str = root.to_string_lossy().to_string();
     assert!(
@@ -201,7 +201,7 @@ fn glob_allow_hidden_root_disables_skip_list() {
 
 #[test]
 fn glob_no_match_returns_clean_empty_result() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     touch(&dir.path().join("a.rs"), "");
     let (msg, is_err) = glob(&json!({
         "pattern": "**/*.zzz",
@@ -239,7 +239,7 @@ fn glob_non_string_pattern_arg_errors_before_search() {
 
 #[test]
 fn grep_finds_literal_pattern_in_file() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let root = dir.path();
     touch(
         &root.join("src/main.rs"),
@@ -267,7 +267,7 @@ fn grep_finds_literal_pattern_in_file() {
 
 #[test]
 fn grep_case_insensitive_flag_widens_matches() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let root = dir.path();
     touch(&root.join("file.txt"), "Hello WORLD\n");
 
@@ -301,7 +301,7 @@ fn grep_case_insensitive_flag_widens_matches() {
 
 #[test]
 fn grep_invalid_regex_errors_cleanly() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     touch(&dir.path().join("x.txt"), "content");
     // Unmatched open paren — invalid regex.
     let (msg, is_err) = grep(&json!({
@@ -317,7 +317,7 @@ fn grep_invalid_regex_errors_cleanly() {
 
 #[test]
 fn grep_no_match_returns_clean_empty_result() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     touch(&dir.path().join("x.txt"), "content");
     let (msg, is_err) = grep(&json!({
         "pattern": "absolutely-not-present-string-zzz",
@@ -350,7 +350,7 @@ fn grep_non_string_pattern_arg_errors_before_search() {
 
 #[test]
 fn grep_anchored_regex_only_matches_at_line_start() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let root = dir.path();
     touch(&root.join("file.txt"), "alpha\nstarts-with-alpha\nXalpha\n");
     // `^alpha` anchors to line start.
@@ -376,7 +376,7 @@ fn grep_redos_resistant_input_completes_within_deadline() {
     // catastrophic-backtrack in PCRE complete quickly. Pin that
     // contract: a long input + a "nested-quantifier" pattern
     // completes in well under 10 seconds.
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let body = "a".repeat(10_000) + "X";
     touch(&dir.path().join("evil.txt"), &body);
 

--- a/tests/file_tools_integration.rs
+++ b/tests/file_tools_integration.rs
@@ -39,7 +39,7 @@ fn write_read_edit_read_cross_tool_flow() {
     let _lock = READ_TRACKER_LOCK.lock().expect("lock");
     reset_read_tracker();
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let sub = dir.path().join("subdir").join("notes.txt");
 
     // ---- Step 1: write creates missing parent directory (Behavior 6) --------
@@ -148,7 +148,7 @@ fn write_read_edit_read_cross_tool_flow() {
 #[test]
 fn write_creates_deeply_nested_parent_directories() {
     // Behavior 6: create_dir_all handles any depth
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let deep = dir
         .path()
         .join("a")
@@ -176,7 +176,7 @@ fn write_creates_deeply_nested_parent_directories() {
 fn read_offset_beyond_eof_is_non_error() {
     // Behavior 1 edge: OC does NOT error when offset > file line count.
     // CC would emit a warning; OC returns an empty body with a suffix.
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("short.txt");
     fs::write(&path, "only one line\n").expect("write");
 
@@ -208,7 +208,7 @@ fn read_large_file_truncated_as_non_error() {
     // Behavior 8: OC silently truncates at 100 000 chars; CC throws an error.
     // Pinned as current OC behavior. CC parity gap: no error flag, no offset
     // guidance in the result.
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("large.txt");
     // Each numbered line is ~208 chars; 600 lines ≈ 124 800 chars → triggers truncation
     let line = "y".repeat(200) + "\n";
@@ -237,7 +237,7 @@ fn read_large_file_truncated_as_non_error() {
 fn read_image_extensions_dispatched_as_image() {
     // Behavior 2: .png, .jpg, .jpeg, .gif, .webp must trigger the image path.
     // We write 1 byte (not valid image data, but enough to confirm dispatch).
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     for ext in &["png", "jpg", "jpeg", "gif", "webp"] {
         let path = dir.path().join(format!("img.{ext}"));
         fs::write(&path, b"\x00").expect("write");
@@ -263,7 +263,7 @@ fn read_image_extensions_dispatched_as_image() {
 
 #[test]
 fn glob_tool_finds_matching_files_through_execute_tool() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     fs::write(dir.path().join("alpha.rs"), "fn alpha() {}\n").expect("write alpha");
     fs::write(dir.path().join("beta.rs"), "fn beta() {}\n").expect("write beta");
     fs::write(dir.path().join("notes.txt"), "not rust\n").expect("write notes");
@@ -296,7 +296,7 @@ fn glob_tool_finds_matching_files_through_execute_tool() {
 
 #[test]
 fn grep_tool_finds_matching_lines_through_execute_tool() {
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     fs::write(
         dir.path().join("src.txt"),
         "first line\nneedle: important result\nlast line\n",
@@ -334,7 +334,7 @@ fn edit_replace_all_multi_occurrence_replaces_every_match() {
     let _lock = READ_TRACKER_LOCK.lock().expect("lock");
     reset_read_tracker();
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("multi.txt");
     fs::write(&path, "foo bar foo baz foo\n").expect("write");
 

--- a/tests/file_tools_race_e2e.rs
+++ b/tests/file_tools_race_e2e.rs
@@ -34,7 +34,7 @@ use openclaudia::tools::{execute_tool, FunctionCall, SessionIdGuard, ToolCall};
 use serde_json::{json, Value};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
-use tempfile::tempdir;
+use tempfile::tempdir_in;
 
 // ───────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -94,7 +94,7 @@ fn edit_without_prior_read_is_refused() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-edit-no-read");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("target.txt");
     std::fs::write(&path, "v1").expect("plant file");
     let path_str = path.to_string_lossy().to_string();
@@ -114,7 +114,7 @@ fn edit_after_read_in_same_session_succeeds() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-edit-after-read");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("target.txt");
     std::fs::write(&path, "alpha").expect("plant");
     let path_str = path.to_string_lossy().to_string();
@@ -134,7 +134,7 @@ fn second_edit_with_same_old_string_errors_because_already_replaced() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-edit-twice");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("target.txt");
     std::fs::write(&path, "unique").expect("plant");
     let path_str = path.to_string_lossy().to_string();
@@ -161,7 +161,7 @@ fn write_to_existing_file_without_read_is_refused() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-write-no-read");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("existing.txt");
     std::fs::write(&path, "existing content").expect("plant");
     let path_str = path.to_string_lossy().to_string();
@@ -181,7 +181,7 @@ fn write_to_new_file_without_read_succeeds() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-write-new");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("brand-new.txt");
     let path_str = path.to_string_lossy().to_string();
     assert!(!path.exists(), "test precondition: file must not exist yet");
@@ -197,7 +197,7 @@ fn write_to_existing_file_after_read_succeeds() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-write-after-read");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("existing.txt");
     std::fs::write(&path, "before").expect("plant");
     let path_str = path.to_string_lossy().to_string();
@@ -219,7 +219,7 @@ fn no_op_edit_is_refused_without_touching_file() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-noop-edit");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("target.txt");
     std::fs::write(&path, "content").expect("plant");
     let path_str = path.to_string_lossy().to_string();
@@ -251,7 +251,7 @@ fn no_op_edit_is_refused_without_touching_file() {
 fn read_in_one_session_does_not_count_in_another() {
     let _sess = session_lock();
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("isolated.txt");
     std::fs::write(&path, "content").expect("plant");
     let path_str = path.to_string_lossy().to_string();
@@ -288,7 +288,7 @@ fn write_creates_missing_parent_directories() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-write-parents");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let nested = dir.path().join("a/b/c/d/file.txt");
     assert!(!nested.parent().unwrap().exists(), "parent dirs absent");
     let path_str = nested.to_string_lossy().to_string();
@@ -312,7 +312,7 @@ fn write_refuses_when_leaf_is_a_symlink() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint21-symlink-leaf");
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempdir_in(".").expect("project-local tempdir");
     let real = dir.path().join("real.txt");
     std::fs::write(&real, "real content").expect("plant real");
     let link = dir.path().join("link.txt");

--- a/tests/glob_grep_dispatch_validation_e2e.rs
+++ b/tests/glob_grep_dispatch_validation_e2e.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 fn dispatch(name: &str, args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -118,7 +119,7 @@ fn glob_permissive_translator_accepts_most_patterns_no_panic() {
 
 #[test]
 fn glob_finds_matching_file_in_tempdir() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("a.rs"), "").expect("write a");
     std::fs::write(dir.path().join("b.rs"), "").expect("write b");
     std::fs::write(dir.path().join("c.txt"), "").expect("write c");
@@ -141,7 +142,7 @@ fn glob_finds_matching_file_in_tempdir() {
 
 #[test]
 fn glob_no_match_returns_clean_output_not_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("x.txt"), "").expect("write");
 
     let args = args_with(&[
@@ -189,7 +190,7 @@ fn grep_pattern_as_array_returns_validation_error() {
 
 #[test]
 fn grep_invalid_regex_pattern_returns_clean_error_not_panic() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("x.txt"), "body").expect("write");
 
     let args = args_with(&[
@@ -210,7 +211,7 @@ fn grep_invalid_regex_pattern_returns_clean_error_not_panic() {
 
 #[test]
 fn grep_literal_pattern_finds_match_in_file() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(
         dir.path().join("hit.txt"),
         "line one\nUNIQUE_MARKER_xyz\nline three\n",
@@ -228,7 +229,7 @@ fn grep_literal_pattern_finds_match_in_file() {
 
 #[test]
 fn grep_case_insensitive_flag_matches_uppercase_lowercase() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("ci.txt"), "Hello WORLD\nlowercase world\n").expect("write");
 
     let args = args_with(&[
@@ -245,7 +246,7 @@ fn grep_case_insensitive_flag_matches_uppercase_lowercase() {
 
 #[test]
 fn grep_default_case_sensitive_skips_wrong_case() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("cs.txt"), "Hello WORLD\nfoo bar\n").expect("write");
 
     let args = args_with(&[
@@ -291,7 +292,7 @@ fn grep_path_as_array_returns_validation_error() {
 
 #[test]
 fn grep_context_lines_above_u64_max_no_panic() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("ctx.txt"), "match\n").expect("write");
 
     let args = args_with(&[
@@ -305,7 +306,7 @@ fn grep_context_lines_above_u64_max_no_panic() {
 
 #[test]
 fn grep_negative_context_lines_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("ctx2.txt"), "match\n").expect("write");
 
     let args = args_with(&[

--- a/tests/grounding_context_dispatch_validation_e2e.rs
+++ b/tests/grounding_context_dispatch_validation_e2e.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 
 fn dispatch(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/hook_policy_sandbox_e2e.rs
+++ b/tests/hook_policy_sandbox_e2e.rs
@@ -6,7 +6,7 @@
 //! covered `HookEntry` + `HookMatcherTarget` serde +
 //! basic `HookPolicy` deserialization; this file pins
 //! the `SandboxMode` 3-variant `snake_case` wire shape,
-//! the `EnvScrub` default, and the `HookPolicy`
+//! the `FullSandbox` default, and the `HookPolicy`
 //! `allowed_commands` None vs Some-empty vs Some-populated
 //! semantics.
 
@@ -21,10 +21,10 @@ use openclaudia::config::{HookPolicy, SandboxMode};
 // ───────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn sandbox_mode_default_is_env_scrub() {
-    // PINS DOCUMENTED DEFAULT: EnvScrub is the documented
-    // default — credentials scrubbed before spawn.
-    assert_eq!(SandboxMode::default(), SandboxMode::EnvScrub);
+fn sandbox_mode_default_is_full_sandbox() {
+    // Repository hooks must be OS-contained unless the host operator
+    // separately makes an explicit trust decision at process startup.
+    assert_eq!(SandboxMode::default(), SandboxMode::FullSandbox);
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -95,16 +95,16 @@ fn hook_policy_default_allowed_commands_is_none() {
 }
 
 #[test]
-fn hook_policy_default_sandbox_is_env_scrub() {
+fn hook_policy_default_sandbox_is_full_sandbox() {
     let policy = HookPolicy::default();
-    assert_eq!(policy.sandbox, SandboxMode::EnvScrub);
+    assert_eq!(policy.sandbox, SandboxMode::FullSandbox);
 }
 
 #[test]
 fn hook_policy_empty_yaml_object_matches_default() {
     let policy: HookPolicy = serde_yaml::from_str("{}").expect("parse empty");
     assert!(policy.allowed_commands.is_none());
-    assert_eq!(policy.sandbox, SandboxMode::EnvScrub);
+    assert_eq!(policy.sandbox, SandboxMode::FullSandbox);
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -145,7 +145,7 @@ fn hook_policy_allowed_commands_dedup_via_hashset() {
 // ───────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn hook_policy_with_sandbox_none_overrides_env_scrub_default() {
+fn hook_policy_with_sandbox_none_overrides_full_sandbox_default() {
     let yaml = "sandbox: none";
     let policy: HookPolicy = serde_yaml::from_str(yaml).expect("parse");
     assert_eq!(policy.sandbox, SandboxMode::None);
@@ -159,7 +159,7 @@ fn hook_policy_with_sandbox_full_sandbox_overrides_default() {
 }
 
 #[test]
-fn hook_policy_with_explicit_env_scrub_matches_default() {
+fn hook_policy_with_explicit_env_scrub_is_a_weaker_explicit_mode() {
     let yaml = "sandbox: env_scrub";
     let policy: HookPolicy = serde_yaml::from_str(yaml).expect("parse");
     assert_eq!(policy.sandbox, SandboxMode::EnvScrub);

--- a/tests/hooks_permissions_e2e.rs
+++ b/tests/hooks_permissions_e2e.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 
-use openclaudia::config::{Hook, HookEntry, HooksConfig};
+use openclaudia::config::{Hook, HookEntry, HookPolicy, HooksConfig, SandboxMode};
 use openclaudia::hooks::{HookEngine, HookEvent, HookInput};
 use openclaudia::permissions::{
     CheckResult, EscalationState, PermissionDecision, PermissionManager, PermissionRule,
@@ -46,7 +46,7 @@ use tempfile::tempdir;
 /// `default_allow=[]` so we never get an unwanted `Allowed` result that
 /// masks a regression.
 fn fresh_manager() -> (PermissionManager, tempfile::TempDir) {
-    let dir = tempdir().expect("tempdir");
+    let dir = tempfile::tempdir_in(".").expect("project-local tempdir");
     let path = dir.path().join("permissions.json");
     let mgr = PermissionManager::new(path, true, Vec::new());
     (mgr, dir)
@@ -113,6 +113,38 @@ async fn command_hook_runs_and_returns_allowed_by_default() {
             .all(|o| o.decision.as_deref() != Some("deny")),
         "no hook decided deny, but outputs say: {:?}",
         result.outputs
+    );
+}
+
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn full_sandbox_hook_cannot_persist_host_temp_write() {
+    let host_dir = tempdir().expect("full-sandbox host tempdir");
+    let host_file = host_dir.path().join("escape.txt");
+    let host_dir_text = host_dir.path().to_string_lossy();
+    let host_file_text = host_file.to_string_lossy();
+    let command = format!(
+        "test \"$OPENCLAUDIA_SANDBOX\" = 1 && mkdir -p {host_dir_text} && \
+         printf escaped > {host_file_text}"
+    );
+    let mut cfg = config_with_command_hook(HookSlot::SessionStart, None, &command, 10);
+    cfg.policy = Some(HookPolicy {
+        allowed_commands: None,
+        sandbox: SandboxMode::FullSandbox,
+    });
+    let engine = HookEngine::new(cfg);
+    let input = HookInput::new(HookEvent::SessionStart);
+
+    let result = engine.run(HookEvent::SessionStart, &input).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "full sandbox hook should succeed in its private temp: {:?}",
+        result.errors
+    );
+    assert!(
+        !host_file.exists(),
+        "full sandbox hook persisted a write to host temp"
     );
 }
 
@@ -205,6 +237,45 @@ async fn timeout_kills_long_running_hook_within_grace_window() {
 }
 
 #[tokio::test]
+#[cfg(target_os = "linux")]
+async fn timeout_kills_hook_descendants_before_they_can_escape_lifetime() {
+    let dir = tempfile::tempdir_in(".").expect("project-local marker directory");
+    let marker = dir.path().join("descendant-survived");
+    let command = format!("(sleep 2; touch '{}') & sleep 60", marker.to_string_lossy());
+    let cfg = config_with_command_hook(HookSlot::SessionStart, None, &command, 1);
+    let engine = HookEngine::new(cfg);
+    let input = HookInput::new(HookEvent::SessionStart);
+
+    let _ = engine.run(HookEvent::SessionStart, &input).await;
+    tokio::time::sleep(std::time::Duration::from_millis(1_500)).await;
+    assert!(
+        !marker.exists(),
+        "a daemonized hook descendant survived timeout cleanup"
+    );
+}
+
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn hook_output_capture_is_bounded() {
+    let command = r#"python3 -c 'print("x" * (2 * 1024 * 1024))'"#;
+    let cfg = config_with_command_hook(HookSlot::SessionStart, None, command, 10);
+    let engine = HookEngine::new(cfg);
+    let input = HookInput::new(HookEvent::SessionStart);
+
+    let result = engine.run(HookEvent::SessionStart, &input).await;
+    let retained = result
+        .outputs
+        .iter()
+        .filter_map(|output| output.additional_context.as_deref())
+        .map(str::len)
+        .sum::<usize>();
+    assert!(
+        retained < 1_100_000,
+        "hook retained {retained} output bytes"
+    );
+}
+
+#[tokio::test]
 async fn user_prompt_submit_matcher_targets_prompt_not_tool_name() {
     // Crosslink #350 regression test: matchers on UserPromptSubmit
     // must test the prompt text, NOT a tool_name (which is absent
@@ -253,7 +324,7 @@ async fn multiple_hooks_in_same_slot_all_run() {
     // Two entries both match (no matcher = unconditional). Both
     // must run. The first prints "first" to additionalContext, the
     // second to systemMessage. Both must end up in outputs.
-    let dir = tempdir().expect("tempdir");
+    let dir = tempfile::tempdir_in(".").expect("project-local tempdir");
     let marker_a = dir.path().join("a.txt");
     let marker_b = dir.path().join("b.txt");
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -35,7 +35,7 @@ fn make_tool_call(name: &str, args: &Value) -> ToolCall {
 
 /// Helper to create a temp directory with test files
 fn setup_test_dir() -> TempDir {
-    let dir = TempDir::new().expect("Failed to create temp dir");
+    let dir = TempDir::new_in(".").expect("Failed to create temp dir");
 
     // Create test file
     fs::write(
@@ -101,7 +101,7 @@ mod file_tools {
         let tool_call = make_tool_call(
             "read_file",
             &json!({
-                "path": "/nonexistent/path/file.txt"
+                "path": "definitely-nonexistent-integration-file.txt"
             }),
         );
 
@@ -154,7 +154,7 @@ mod file_tools {
 
     #[test]
     fn test_write_file_new() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("new_file.txt");
 
         let tool_call = make_tool_call(
@@ -329,7 +329,7 @@ mod file_tools {
 
     #[test]
     fn test_read_file_unicode_content() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("unicode.txt");
 
         // Write Unicode content including emojis and various scripts
@@ -356,7 +356,7 @@ mod file_tools {
 
     #[test]
     fn test_write_file_unicode_content() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("unicode_write.txt");
 
         let unicode_content = "Writing Unicode: 你好 🌍 مرحبا";
@@ -382,7 +382,7 @@ mod file_tools {
 
     #[test]
     fn test_read_file_empty() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("empty.txt");
         fs::write(&file_path, "").expect("Failed to write empty file");
 
@@ -404,7 +404,7 @@ mod file_tools {
 
     #[test]
     fn test_read_file_large() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("large.txt");
 
         // Create a large file (10000 lines)
@@ -437,7 +437,7 @@ mod file_tools {
 
     #[test]
     fn test_read_file_with_limit_large() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("large_limit.txt");
 
         let content: String = (0..1000).fold(String::new(), |mut s, i| {
@@ -469,7 +469,7 @@ mod file_tools {
     fn test_edit_file_multiline() {
         let _lock = READ_TRACKER_LOCK.lock().unwrap();
         reset_read_tracker(); // Clear tracker for clean test state
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("multiline.txt");
 
         let original = "function foo() {\n    console.log('old');\n}";
@@ -508,7 +508,7 @@ mod file_tools {
     fn test_edit_file_special_characters() {
         let _lock = READ_TRACKER_LOCK.lock().unwrap();
         reset_read_tracker(); // Clear tracker for clean test state
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("special.txt");
 
         let original = "Price: $100 (50% off!) [limited]";
@@ -565,7 +565,7 @@ mod file_tools {
 
     #[test]
     fn test_write_file_creates_parent_dirs() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("new_dir/sub_dir/file.txt");
 
         let tool_call = make_tool_call(
@@ -590,7 +590,7 @@ mod file_tools {
 
     #[test]
     fn test_read_file_binary_detection() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("binary.bin");
 
         // Write some binary content (PNG magic bytes + nulls)
@@ -630,7 +630,7 @@ mod file_tools {
     fn test_edit_file_without_prior_read() {
         let _lock = READ_TRACKER_LOCK.lock().unwrap();
         reset_read_tracker();
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("unread.txt");
         fs::write(&file_path, "original content").expect("Failed to write");
 
@@ -667,7 +667,7 @@ mod file_tools {
 
     #[test]
     fn test_write_file_empty_content() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("empty_write.txt");
 
         let tool_call = make_tool_call(
@@ -695,7 +695,7 @@ mod file_tools {
     fn test_edit_file_identical_old_new() {
         let _lock = READ_TRACKER_LOCK.lock().unwrap();
         reset_read_tracker();
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let file_path = dir.path().join("identical.txt");
         fs::write(&file_path, "some content here").expect("Failed to write");
 
@@ -748,7 +748,7 @@ mod file_tools {
 
     #[test]
     fn test_write_file_very_long_filename() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let long_name = "a".repeat(300);
         let file_path = dir.path().join(&long_name);
 
@@ -840,13 +840,21 @@ mod bash_tools {
 
     #[test]
     fn test_bash_working_directory() {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = tempfile::Builder::new()
+            .prefix("openclaudia-bash-cwd-")
+            .tempdir_in(".")
+            .expect("Failed to create project temp dir");
 
         // Create a file in the temp dir
         fs::write(dir.path().join("marker.txt"), "exists").expect("write failed");
 
         // Convert Windows path to Unix-style for bash
-        let path_str = dir.path().to_string_lossy().replace('\\', "/");
+        let path_str = dir
+            .path()
+            .canonicalize()
+            .expect("canonical project temp dir")
+            .to_string_lossy()
+            .replace('\\', "/");
 
         let tool_call = make_tool_call(
             "bash",
@@ -1374,7 +1382,7 @@ mod auto_learn_integration {
     use openclaudia::auto_learn::AutoLearner;
 
     fn setup_memory_db() -> (TempDir, MemoryDb) {
-        let dir = TempDir::new().expect("Failed to create temp dir");
+        let dir = TempDir::new_in(".").expect("Failed to create temp dir");
         let db_path = dir.path().join("test_memory.db");
         let db = MemoryDb::open(&db_path).expect("Failed to create memory db");
         (dir, db)

--- a/tests/list_files_dispatch_validation_e2e.rs
+++ b/tests/list_files_dispatch_validation_e2e.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 fn dispatch_list(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -85,7 +86,7 @@ fn path_with_parent_dir_traversal_rejected() {
 
 #[test]
 fn nonexistent_path_errors_with_documented_message() {
-    let args = args_with(&[("path", json!("/tmp/definitely_nonexistent_xyz_marker_153"))]);
+    let args = args_with(&[("path", json!("definitely_nonexistent_xyz_marker_153"))]);
     let (msg, is_err) = dispatch_list(&args);
     assert!(is_err);
     assert!(
@@ -104,7 +105,7 @@ fn nonexistent_path_errors_with_documented_message() {
 
 #[test]
 fn lists_files_in_tempdir() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("alpha.txt"), "").expect("write a");
     std::fs::write(dir.path().join("beta.rs"), "").expect("write b");
     std::fs::write(dir.path().join("gamma.md"), "").expect("write g");
@@ -119,7 +120,7 @@ fn lists_files_in_tempdir() {
 
 #[test]
 fn lists_empty_dir_returns_empty_output_not_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let args = args_with(&[("path", json!(dir.path().to_str().unwrap()))]);
     let (text, is_err) = dispatch_list(&args);
     assert!(!is_err);
@@ -135,7 +136,7 @@ fn lists_empty_dir_returns_empty_output_not_error() {
 
 #[test]
 fn directories_marked_with_trailing_slash() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::create_dir(dir.path().join("subdir")).expect("mkdir");
     std::fs::write(dir.path().join("file.txt"), "").expect("write");
 
@@ -154,7 +155,7 @@ fn directories_marked_with_trailing_slash() {
 #[test]
 fn dirs_appear_before_files_in_output() {
     // PINS #953: dirs-before-files alphabetical layout.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     // Use names that would mix if simple alphabetical.
     std::fs::write(dir.path().join("a_file.txt"), "").expect("write");
     std::fs::create_dir(dir.path().join("z_dir")).expect("mkdir");
@@ -187,7 +188,7 @@ fn dirs_appear_before_files_in_output() {
 #[test]
 fn nested_dirs_listed_at_only_top_level() {
     // list_files is non-recursive.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::create_dir(dir.path().join("outer")).expect("mkdir outer");
     std::fs::write(dir.path().join("outer/inner.txt"), "").expect("write inner");
 
@@ -207,7 +208,7 @@ fn nested_dirs_listed_at_only_top_level() {
 
 #[test]
 fn unicode_filename_listed_byte_exact() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     std::fs::write(dir.path().join("日本語.txt"), "").expect("write unicode");
     std::fs::create_dir(dir.path().join("フォルダ")).expect("mkdir unicode");
 
@@ -228,7 +229,7 @@ fn list_files_registered_in_registry() {
 
 #[test]
 fn list_files_never_panics_on_arbitrary_extra_args() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let args = args_with(&[
         ("path", json!(dir.path().to_str().unwrap())),
         ("extra", json!({"k": "v"})),
@@ -240,7 +241,7 @@ fn list_files_never_panics_on_arbitrary_extra_args() {
 
 #[test]
 fn list_files_path_to_regular_file_errors_cleanly() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let f = dir.path().join("just_a_file.txt");
     std::fs::write(&f, "body").expect("write");
 

--- a/tests/lsp_tool_validation_e2e.rs
+++ b/tests/lsp_tool_validation_e2e.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 fn dispatch_lsp(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -31,7 +31,7 @@ use openclaudia::mcp::{
     HttpTransport, McpError, McpManager, McpServer, McpServerConfig, StdioTransport,
 };
 use openclaudia::plugins::PluginManager;
-use openclaudia::proxy::connect_mcp_servers;
+use openclaudia::proxy::connect_mcp_servers_with_trust;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -289,7 +289,12 @@ async fn plugin_mcp_stdio_env_reaches_child_process() {
     let plugins = Arc::new(plugins);
     let manager = Arc::new(RwLock::new(McpManager::new()));
 
-    connect_mcp_servers(&manager, &plugins).await;
+    connect_mcp_servers_with_trust(
+        &manager,
+        &plugins,
+        &std::collections::HashSet::from(["env-plugin/env-server".to_string()]),
+    )
+    .await;
 
     let functions = {
         let mcp = manager.read().await;
@@ -301,6 +306,157 @@ async fn plugin_mcp_stdio_env_reaches_child_process() {
     assert!(
         functions.is_empty(),
         "plugin MCP env var must suppress fixture tools; non-empty tools means env was dropped"
+    );
+}
+
+#[tokio::test]
+async fn repository_mcp_server_requires_exact_host_trust_and_revocation_disconnects_it() {
+    let root = TempDir::new().expect("tempdir");
+    let plugin_dir = root.path().join("trust-plugin");
+    std::fs::create_dir_all(&plugin_dir).expect("plugin dir");
+    let fixture_json = serde_json::to_string(fixture_path().to_str().expect("fixture path utf-8"))
+        .expect("fixture path json");
+    std::fs::write(
+        plugin_dir.join("plugin.json"),
+        format!(
+            r#"{{
+                "name": "trust-plugin",
+                "mcpServers": {{
+                    "trust-server": {{
+                        "transport": "stdio",
+                        "command": "python3",
+                        "args": [{fixture_json}]
+                    }}
+                }}
+            }}"#
+        ),
+    )
+    .expect("manifest");
+    let mut plugins = PluginManager::with_paths(vec![root.path().to_path_buf()]);
+    assert!(plugins.discover().is_empty());
+    let plugins = Arc::new(plugins);
+    let manager = Arc::new(RwLock::new(McpManager::new()));
+
+    connect_mcp_servers_with_trust(&manager, &plugins, &std::collections::HashSet::new()).await;
+    assert!(
+        !manager.read().await.is_connected("trust-server").await,
+        "repository MCP must remain disconnected before explicit trust"
+    );
+
+    connect_mcp_servers_with_trust(
+        &manager,
+        &plugins,
+        &std::collections::HashSet::from(["trust-plugin/trust-server".to_string()]),
+    )
+    .await;
+    assert!(manager.read().await.is_live("trust-server").await);
+
+    connect_mcp_servers_with_trust(&manager, &plugins, &std::collections::HashSet::new()).await;
+    assert!(
+        !manager.read().await.is_connected("trust-server").await,
+        "revocation must terminate and unregister the trusted server"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn stdio_mcp_rejects_an_executable_from_an_agent_writable_root() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let executable =
+        tempfile::NamedTempFile::new_in(".").expect("project-local executable fixture");
+    std::fs::set_permissions(executable.path(), std::fs::Permissions::from_mode(0o755))
+        .expect("executable mode");
+    let result = StdioTransport::spawn(
+        executable.path().to_str().expect("utf-8 executable path"),
+        &[],
+    );
+    let Err(error) = result else {
+        panic!("project executable must not become an MCP host extension");
+    };
+    assert!(
+        error.to_string().contains("agent-writable"),
+        "unexpected executable trust error: {error}"
+    );
+}
+
+#[test]
+fn stdio_mcp_rejects_sensitive_environment_without_an_exact_host_grant() {
+    let key = "OPENCLAUDIA_TEST_MCP_PRIVATE_TOKEN";
+    let env = HashMap::from([(key.to_string(), "canary-value".to_string())]);
+    let Err(error) = StdioTransport::spawn_with_env("python3", &["-c", "pass"], &env) else {
+        panic!("sensitive MCP env must require an exact host grant");
+    };
+    assert!(
+        error.to_string().contains(key) && error.to_string().contains("host operator"),
+        "unexpected environment-grant error: {error}"
+    );
+}
+
+#[test]
+fn stdio_mcp_rejects_host_dynamic_loader_environment() {
+    let env = HashMap::from([(
+        "LD_PRELOAD".to_string(),
+        "./repository-controlled-library.so".to_string(),
+    )]);
+    let Err(error) = StdioTransport::spawn_with_env("python3", &["-c", "pass"], &env) else {
+        panic!("MCP env must not influence the host sandbox launcher");
+    };
+    assert!(
+        error.to_string().contains("dynamic loader"),
+        "unexpected loader-environment error: {error}"
+    );
+}
+
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn stdio_mcp_sandbox_blocks_host_file_and_network_access() {
+    let outside = TempDir::new().expect("outside tempdir");
+    let sentinel = outside.path().join("host-sentinel");
+    std::fs::write(&sentinel, "outside-secret").expect("sentinel");
+    let path_literal =
+        serde_json::to_string(sentinel.to_str().expect("utf-8 sentinel")).expect("json path");
+    let script = format!(
+        r#"
+import json, socket, sys
+blocked_file = False
+blocked_network = False
+try:
+    open({path_literal}, "rb").read()
+except OSError:
+    blocked_file = True
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+except OSError:
+    blocked_network = True
+
+def reply(i, result):
+    print(json.dumps({{"jsonrpc":"2.0","id":i,"result":result}}), flush=True)
+
+request = json.loads(sys.stdin.readline())
+reply(request["id"], {{
+    "protocolVersion":"2024-11-05",
+    "capabilities":{{"tools":{{"listChanged":False}}}},
+    "serverInfo":{{"name":"sandbox-probe","version":"1"}}
+}})
+request = json.loads(sys.stdin.readline())
+reply(request["id"], None)
+request = json.loads(sys.stdin.readline())
+name = "sandbox_blocked" if blocked_file and blocked_network else "sandbox_escaped"
+reply(request["id"], {{"tools":[{{"name":name,"inputSchema":{{"type":"object"}}}}]}})
+"#
+    );
+    let transport =
+        StdioTransport::spawn("python3", &["-u", "-c", &script]).expect("sandboxed MCP");
+    let server = McpServer::new("sandbox-probe", Box::new(transport))
+        .await
+        .expect("probe handshake");
+    assert!(
+        server
+            .tools()
+            .iter()
+            .any(|tool| tool.name == "sandbox_blocked"),
+        "sandboxed MCP reached a host file or network socket"
     );
 }
 

--- a/tests/mcp_resource_handler_e2e.rs
+++ b/tests/mcp_resource_handler_e2e.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 
 fn dispatch(name: &str, args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/notebook_edit_dispatch_validation_e2e.rs
+++ b/tests/notebook_edit_dispatch_validation_e2e.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 
 fn dispatch_notebook(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -74,7 +75,7 @@ fn notebook_path_as_null_returns_validation_error() {
 
 #[test]
 fn missing_new_source_arg_returns_documented_error() {
-    let args = args_with(&[("notebook_path", json!("/tmp/x.ipynb"))]);
+    let args = args_with(&[("notebook_path", json!("x.ipynb"))]);
     let (msg, is_err) = dispatch_notebook(&args);
     assert!(is_err);
     assert!(
@@ -86,7 +87,7 @@ fn missing_new_source_arg_returns_documented_error() {
 #[test]
 fn new_source_as_number_returns_validation_error() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/x.ipynb")),
+        ("notebook_path", json!("x.ipynb")),
         ("new_source", json!(42)),
     ]);
     let (msg, is_err) = dispatch_notebook(&args);
@@ -117,7 +118,7 @@ fn missing_both_args_surfaces_notebook_path_error_first() {
 #[test]
 fn invalid_edit_mode_returns_documented_3_choice_error() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/x.ipynb")),
+        ("notebook_path", json!("x.ipynb")),
         ("new_source", json!("body")),
         ("edit_mode", json!("not_a_real_mode")),
     ]);
@@ -137,7 +138,7 @@ fn invalid_edit_mode_returns_documented_3_choice_error() {
 #[test]
 fn edit_mode_as_number_returns_validation_error() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/x.ipynb")),
+        ("notebook_path", json!("x.ipynb")),
         ("new_source", json!("body")),
         ("edit_mode", json!(42)),
     ]);
@@ -151,7 +152,7 @@ fn edit_mode_replace_passes_enum_check() {
     // Valid edit_mode — fails downstream (file doesn't exist) but
     // NOT with the enum error.
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent_nb_xyz.ipynb")),
+        ("notebook_path", json!("nonexistent_nb_xyz.ipynb")),
         ("new_source", json!("body")),
         ("edit_mode", json!("replace")),
     ]);
@@ -166,7 +167,7 @@ fn edit_mode_replace_passes_enum_check() {
 #[test]
 fn edit_mode_insert_passes_enum_check() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("edit_mode", json!("insert")),
     ]);
@@ -178,7 +179,7 @@ fn edit_mode_insert_passes_enum_check() {
 #[test]
 fn edit_mode_delete_passes_enum_check() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("edit_mode", json!("delete")),
     ]);
@@ -191,7 +192,7 @@ fn edit_mode_delete_passes_enum_check() {
 fn missing_edit_mode_defaults_to_replace() {
     // PINS DEFAULT: omitted edit_mode → "replace" (no enum error).
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
     ]);
     let (msg, is_err) = dispatch_notebook(&args);
@@ -211,7 +212,7 @@ fn invalid_cell_type_returns_documented_nbformat_error() {
     // PINS #985: cell_type must be in nbformat allowlist
     // {code, markdown, raw}.
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/x.ipynb")),
+        ("notebook_path", json!("x.ipynb")),
         ("new_source", json!("body")),
         ("cell_type", json!("bogus_type")),
     ]);
@@ -230,7 +231,7 @@ fn invalid_cell_type_returns_documented_nbformat_error() {
 #[test]
 fn cell_type_as_number_returns_validation_error() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/x.ipynb")),
+        ("notebook_path", json!("x.ipynb")),
         ("new_source", json!("body")),
         ("cell_type", json!(42)),
     ]);
@@ -242,7 +243,7 @@ fn cell_type_as_number_returns_validation_error() {
 #[test]
 fn cell_type_code_passes_enum_check() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("cell_type", json!("code")),
     ]);
@@ -254,7 +255,7 @@ fn cell_type_code_passes_enum_check() {
 #[test]
 fn cell_type_markdown_passes_enum_check() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("cell_type", json!("markdown")),
     ]);
@@ -266,7 +267,7 @@ fn cell_type_markdown_passes_enum_check() {
 #[test]
 fn cell_type_raw_passes_enum_check() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("cell_type", json!("raw")),
     ]);
@@ -279,7 +280,7 @@ fn cell_type_raw_passes_enum_check() {
 fn missing_cell_type_arg_passes_enum_check() {
     // PINS DOC: cell_type is optional.
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
     ]);
     let (msg, is_err) = dispatch_notebook(&args);
@@ -297,7 +298,7 @@ fn cell_number_above_usize_range_returns_platform_specific_error() {
     // the try_from succeeds and the value passes through. We
     // just verify no panic + reasonable error path.
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("cell_number", json!(u64::MAX)),
     ]);
@@ -310,7 +311,7 @@ fn cell_number_above_usize_range_returns_platform_specific_error() {
 #[test]
 fn cell_number_negative_is_rejected_as_non_u64() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("cell_number", json!(-1)),
     ]);
@@ -322,7 +323,7 @@ fn cell_number_negative_is_rejected_as_non_u64() {
 #[test]
 fn cell_id_as_number_returns_validation_error() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/nonexistent.ipynb")),
+        ("notebook_path", json!("nonexistent.ipynb")),
         ("new_source", json!("body")),
         ("cell_id", json!(42)),
     ]);
@@ -338,7 +339,7 @@ fn cell_id_as_number_returns_validation_error() {
 #[test]
 fn dispatch_never_panics_on_arbitrary_extra_args() {
     let args = args_with(&[
-        ("notebook_path", json!("/tmp/x.ipynb")),
+        ("notebook_path", json!("x.ipynb")),
         ("new_source", json!("body")),
         ("unknown_arg", json!("ignored")),
         ("nested", json!([1, 2, 3])),

--- a/tests/notebook_edit_e2e.rs
+++ b/tests/notebook_edit_e2e.rs
@@ -160,7 +160,7 @@ fn replace_cell_by_id_rewrites_source() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-replace");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     let nb = make_notebook(&[
         ("c1", "code", "print('one')"),
@@ -202,7 +202,7 @@ fn insert_cell_grows_notebook_by_one() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-insert");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     let nb = make_notebook(&[("c1", "code", "x = 1")]);
     write_notebook(&path, &nb);
@@ -234,7 +234,7 @@ fn delete_cell_shrinks_notebook_by_one() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-delete");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     let nb = make_notebook(&[
         ("c1", "code", "x = 1"),
@@ -277,7 +277,7 @@ fn invalid_edit_mode_is_refused() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-bad-mode");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     write_notebook(&path, &make_notebook(&[("c1", "code", "x = 1")]));
     let path_str = path.to_string_lossy().to_string();
@@ -301,7 +301,7 @@ fn invalid_cell_type_on_insert_is_refused() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-bad-celltype");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     write_notebook(&path, &make_notebook(&[("c1", "code", "x = 1")]));
     let path_str = path.to_string_lossy().to_string();
@@ -326,7 +326,7 @@ fn unknown_cell_id_on_replace_is_refused() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-unknown-id");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     write_notebook(&path, &make_notebook(&[("c1", "code", "x = 1")]));
     let path_str = path.to_string_lossy().to_string();
@@ -369,7 +369,7 @@ fn symlink_leaf_notebook_path_is_refused_through_public_dispatch() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-symlink-leaf");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let target = dir.path().join("target.ipynb");
     let nb = make_notebook(&[("guarded", "code", "SAFE")]);
     write_notebook(&target, &nb);
@@ -417,7 +417,7 @@ fn nbformat_top_level_fields_survive_edit() {
     let _sess = session_lock();
     let _guard = SessionIdGuard::set("sprint23-schema");
 
-    let dir = TempDir::new().expect("tempdir");
+    let dir = TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("nb.ipynb");
     let nb = make_notebook(&[("c1", "code", "x = 1")]);
     write_notebook(&path, &nb);

--- a/tests/plan_mode_exit_validation_e2e.rs
+++ b/tests/plan_mode_exit_validation_e2e.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 fn dispatch_exit_plan_mode(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -30,6 +31,7 @@ fn dispatch_exit_plan_mode(args: &HashMap<String, Value>) -> (String, bool) {
 
 fn dispatch_enter_plan_mode() -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/read_file_dispatch_validation_e2e.rs
+++ b/tests/read_file_dispatch_validation_e2e.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 
 fn dispatch_read(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -76,7 +77,7 @@ fn path_arg_as_null_returns_validation_error() {
 
 #[test]
 fn pdf_pages_arg_as_number_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("bad_pages.pdf");
     std::fs::write(&path, b"%PDF-1.4\n").expect("write");
 
@@ -107,10 +108,7 @@ fn parent_dir_traversal_in_path_rejected() {
 
 #[test]
 fn nonexistent_path_errors_with_stat_message() {
-    let args = args_with(&[(
-        "path",
-        json!("/tmp/definitely_nonexistent_xyz_marker_144.txt"),
-    )]);
+    let args = args_with(&[("path", json!("definitely_nonexistent_xyz_marker_144.txt"))]);
     let (msg, is_err) = dispatch_read(&args);
     assert!(is_err);
     assert!(
@@ -130,7 +128,7 @@ fn nonexistent_path_errors_with_stat_message() {
 
 #[test]
 fn read_simple_text_file_returns_content_with_line_numbers() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("simple.txt");
     std::fs::write(&path, "line one\nline two\nline three\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -156,7 +154,7 @@ fn read_file_records_observation_when_session_ledger_is_active() {
     let _ledger_guard =
         openclaudia::ledger::install_active_ledger_for_session("readledger", Arc::clone(&ledger));
 
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("ledgered.txt");
     std::fs::write(&path, "alpha\nbeta\n").expect("write");
 
@@ -202,7 +200,7 @@ fn read_file_records_observation_when_session_ledger_is_active() {
 
 #[test]
 fn read_empty_file_returns_no_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("empty.txt");
     std::fs::write(&path, "").expect("write");
     let path_str = path.to_str().unwrap();
@@ -214,7 +212,7 @@ fn read_empty_file_returns_no_error() {
 
 #[test]
 fn read_unicode_content_preserves_bytes() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("unicode.txt");
     std::fs::write(&path, "日本語コンテンツ\n🎉 emoji line\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -232,7 +230,7 @@ fn read_unicode_content_preserves_bytes() {
 
 #[test]
 fn offset_skips_initial_lines() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("offset.txt");
     let body = (1..=10)
         .map(|i| format!("line_{i}_marker"))
@@ -256,7 +254,7 @@ fn offset_skips_initial_lines() {
 
 #[test]
 fn limit_caps_returned_lines() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("limit.txt");
     let body = (1..=10)
         .map(|i| format!("limit_line_{i}_marker"))
@@ -279,7 +277,7 @@ fn limit_caps_returned_lines() {
 
 #[test]
 fn offset_plus_limit_window_selection() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("window.txt");
     let body = (1..=20)
         .map(|i| format!("win_{i}"))
@@ -304,7 +302,7 @@ fn offset_plus_limit_window_selection() {
 
 #[test]
 fn offset_beyond_file_length_returns_no_lines_but_no_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("offset_huge.txt");
     std::fs::write(&path, "only one line\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -317,7 +315,7 @@ fn offset_beyond_file_length_returns_no_lines_but_no_error() {
 
 #[test]
 fn offset_zero_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("offset_zero.txt");
     std::fs::write(&path, "first\nsecond\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -333,7 +331,7 @@ fn offset_zero_returns_validation_error() {
 
 #[test]
 fn limit_zero_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("limit_zero.txt");
     std::fs::write(&path, "first\nsecond\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -349,7 +347,7 @@ fn limit_zero_returns_validation_error() {
 
 #[test]
 fn offset_above_u64_max_coerces_no_panic() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("offset_max.txt");
     std::fs::write(&path, "x\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -362,7 +360,7 @@ fn offset_above_u64_max_coerces_no_panic() {
 
 #[test]
 fn limit_above_u64_max_coerces_no_panic() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("limit_max.txt");
     std::fs::write(&path, "a\nb\nc\n").expect("write");
     let path_str = path.to_str().unwrap();
@@ -388,7 +386,7 @@ fn missing_path_arg_takes_precedence_over_invalid_offset() {
 
 #[test]
 fn read_dispatch_never_panics_on_arbitrary_extra_args() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("extras.txt");
     std::fs::write(&path, "body\n").expect("write");
     let path_str = path.to_str().unwrap();

--- a/tests/registry_dispatch_envelope_e2e.rs
+++ b/tests/registry_dispatch_envelope_e2e.rs
@@ -18,8 +18,9 @@ use openclaudia::tools::registry::{registry, ToolContext};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
-const fn ctx() -> ToolContext<'static> {
+fn ctx() -> ToolContext<'static> {
     ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -237,7 +238,7 @@ fn dispatch_repeated_with_same_args_returns_consistent_envelope_shape() {
     // PINS IDEMPOTENCY: read-only tools (list_files) with the
     // same args produce same envelope shape on every call.
     let mut c = ctx();
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let args: HashMap<String, Value> =
         vec![("path".to_string(), json!(dir.path().to_str().unwrap()))]
             .into_iter()

--- a/tests/registry_dispatch_options_e2e.rs
+++ b/tests/registry_dispatch_options_e2e.rs
@@ -17,8 +17,9 @@ fn empty_args() -> HashMap<String, serde_json::Value> {
     HashMap::new()
 }
 
-const fn fresh_ctx() -> ToolContext<'static> {
+fn fresh_ctx() -> ToolContext<'static> {
     ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -221,6 +222,7 @@ fn dispatch_works_with_all_none_context_fields() {
     // default for tools that don't need memory_db/app_config/task_mgr.
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -233,6 +235,7 @@ fn dispatch_works_with_all_none_context_fields() {
 fn dispatch_does_not_panic_on_unknown_with_all_none_context() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/registry_global_invariants_e2e.rs
+++ b/tests/registry_global_invariants_e2e.rs
@@ -307,6 +307,7 @@ fn notebook_edit_permission_target_uses_notebook_path_arg_key() {
 fn every_documented_tool_dispatches_to_some_result() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/sandbox_escape_e2e.rs
+++ b/tests/sandbox_escape_e2e.rs
@@ -1,0 +1,343 @@
+//! Deterministic local escape probes for the Linux agent sandbox.
+//!
+//! Every sentinel and listener is owned by this test process. No probe reads
+//! unrelated host data or contacts an external network.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::expect_used)]
+#![allow(clippy::missing_panics_doc)]
+
+use openclaudia::tools::{execute_tool, FunctionCall, ToolCall};
+use serde_json::json;
+use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+use std::os::unix::net::UnixListener;
+
+fn bash(command: &str) -> openclaudia::tools::ToolResult {
+    execute_tool(&ToolCall {
+        id: "sandbox-escape-probe".to_string(),
+        call_type: "function".to_string(),
+        function: FunctionCall {
+            name: "bash".to_string(),
+            arguments: json!({"command": command}).to_string(),
+        },
+    })
+}
+
+fn project_fixture(prefix: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in(".")
+        .expect("project-local fixture")
+}
+
+#[test]
+fn host_file_network_and_kernel_trees_are_absent() {
+    let outside = tempfile::tempdir().expect("host sentinel dir");
+    let sentinel = outside.path().join("sentinel");
+    std::fs::write(&sentinel, "host-secret").expect("host sentinel");
+    let quoted = shlex::try_quote(sentinel.to_str().expect("UTF-8 sentinel")).expect("quote");
+    let python = r#"
+import errno, socket
+blocked = []
+for family, kind in [(socket.AF_INET, socket.SOCK_STREAM), (socket.AF_INET6, socket.SOCK_DGRAM), (socket.AF_UNIX, socket.SOCK_STREAM)]:
+    try:
+        socket.socket(family, kind)
+        blocked.append(False)
+    except OSError as error:
+        blocked.append(error.errno in (errno.EPERM, errno.EACCES))
+print("network_blocked=" + str(all(blocked)).lower())
+"#;
+    let python = shlex::try_quote(python).expect("quote Python");
+    let result = bash(&format!(
+        "if test -e {quoted}; then echo host_file_visible; else echo host_file_blocked; fi; \
+         if test -e /sys/kernel; then echo sys_visible; else echo sys_blocked; fi; \
+         python3 -c {python}"
+    ));
+    assert!(!result.is_error, "probe failed: {}", result.content);
+    assert!(result.content.contains("host_file_blocked"));
+    assert!(result.content.contains("sys_blocked"));
+    assert!(result.content.contains("network_blocked=true"));
+    assert!(!result.content.contains("host-secret"));
+}
+
+#[test]
+fn project_socket_and_fifo_block_sandbox_startup() {
+    let fixture = project_fixture(".tmp-openclaudia-special-");
+    let socket = fixture.path().join("service.sock");
+    let listener = UnixListener::bind(&socket).expect("local Unix listener");
+    let socket_result = bash("true");
+    assert!(
+        socket_result.is_error && socket_result.content.contains("socket, FIFO, or device"),
+        "project socket was not rejected: {}",
+        socket_result.content
+    );
+    drop(listener);
+    std::fs::remove_file(&socket).expect("remove socket");
+
+    let fifo = fixture.path().join("pipe");
+    let fifo_c = std::ffi::CString::new(fifo.as_os_str().as_encoded_bytes()).expect("FIFO path");
+    assert_eq!(unsafe { libc::mkfifo(fifo_c.as_ptr(), 0o600) }, 0);
+    let fifo_result = bash("true");
+    assert!(
+        fifo_result.is_error && fifo_result.content.contains("socket, FIFO, or device"),
+        "project FIFO was not rejected: {}",
+        fifo_result.content
+    );
+}
+
+#[test]
+fn external_hardlink_alias_is_rejected_but_internal_alias_is_supported() {
+    let outside = tempfile::Builder::new()
+        .prefix(".tmp-openclaudia-outside-hardlink-")
+        .tempdir_in("..")
+        .expect("same-filesystem outside dir");
+    let sentinel = outside.path().join("sentinel");
+    std::fs::write(&sentinel, "unchanged").expect("sentinel");
+    let fixture = project_fixture(".tmp-openclaudia-hardlink-");
+    let alias = fixture.path().join("outside-alias");
+    std::fs::hard_link(&sentinel, &alias).expect("same-filesystem hardlink fixture");
+    let rejected = bash("true");
+    assert!(
+        rejected.is_error,
+        "external hardlink alias must block startup"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&sentinel).expect("sentinel"),
+        "unchanged"
+    );
+    std::fs::remove_file(&alias).expect("remove external alias");
+
+    let first = fixture.path().join("internal-a");
+    let second = fixture.path().join("internal-b");
+    std::fs::write(&first, "before").expect("internal file");
+    std::fs::hard_link(&first, &second).expect("internal hardlink");
+    let command = format!(
+        "printf changed > {}",
+        shlex::try_quote(first.to_str().expect("UTF-8 path")).expect("quote")
+    );
+    let allowed = bash(&command);
+    assert!(
+        !allowed.is_error,
+        "internal hardlinks should be usable: {}",
+        allowed.content
+    );
+    assert_eq!(
+        std::fs::read_to_string(second).expect("internal alias"),
+        "changed"
+    );
+}
+
+#[test]
+fn inherited_host_file_descriptor_is_closed() {
+    let outside = tempfile::NamedTempFile::new().expect("outside sentinel");
+    std::fs::write(outside.path(), "fd-secret").expect("sentinel contents");
+    let path = std::ffi::CString::new(outside.path().as_os_str().as_encoded_bytes()).expect("path");
+    let raw = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
+    assert!(raw >= 0, "open inherited descriptor");
+    let inherited = unsafe { OwnedFd::from_raw_fd(raw) };
+    let result = bash(&format!(
+        "cat /proc/self/fd/{} 2>/dev/null || echo fd_blocked",
+        inherited.as_raw_fd()
+    ));
+    assert!(
+        !result.content.contains("fd-secret"),
+        "host FD leaked: {}",
+        result.content
+    );
+    assert!(result.content.contains("fd_blocked"));
+}
+
+#[test]
+fn seccomp_denies_socket_unshare_and_ptrace_syscalls() {
+    let python = r#"
+import ctypes, errno, socket
+libc = ctypes.CDLL(None, use_errno=True)
+checks = []
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    checks.append(False)
+except OSError as error:
+    checks.append(error.errno == errno.EPERM)
+checks.append(libc.unshare(0x10000000) == -1 and ctypes.get_errno() == errno.EPERM)
+ctypes.set_errno(0)
+checks.append(libc.ptrace(0, 0, 0, 0) == -1 and ctypes.get_errno() == errno.EPERM)
+print("seccomp_blocked=" + str(all(checks)).lower())
+"#;
+    let result = bash(&format!(
+        "python3 -c {}",
+        shlex::try_quote(python).expect("quote Python")
+    ));
+    assert!(!result.is_error, "seccomp probe failed: {}", result.content);
+    assert!(result.content.contains("seccomp_blocked=true"));
+}
+
+#[test]
+fn effective_rlimits_include_process_memory_cpu_file_and_fd_caps() {
+    let result = bash(
+        "printf 'cpu=%s nofile=%s fsize=%s as=%s nproc=%s\\n' \
+         \"$(ulimit -t)\" \"$(ulimit -n)\" \"$(ulimit -f)\" \"$(ulimit -v)\" \"$(ulimit -u)\"",
+    );
+    assert!(!result.is_error, "rlimit probe failed: {}", result.content);
+    assert!(result.content.contains("cpu=300"));
+    assert!(result.content.contains("nofile=1024"));
+    assert!(
+        !result.content.contains("fsize=unlimited"),
+        "file-size limit was not applied: {}",
+        result.content
+    );
+    assert!(result.content.contains("as=4194304"));
+}
+
+#[test]
+fn process_count_limit_stops_a_fork_flood() {
+    let python = r#"
+import os, time
+children = []
+for _ in range(300):
+    try:
+        pid = os.fork()
+    except OSError:
+        break
+    if pid == 0:
+        time.sleep(0.25)
+        os._exit(0)
+    children.append(pid)
+for pid in children:
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+print("children=" + str(len(children)))
+"#;
+    let result = bash(&format!(
+        "python3 -c {}",
+        shlex::try_quote(python).expect("quote Python")
+    ));
+    assert!(
+        !result.is_error,
+        "fork-limit probe failed: {}",
+        result.content
+    );
+    let count = result
+        .content
+        .split("children=")
+        .nth(1)
+        .and_then(|tail| tail.lines().next())
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .expect("child count");
+    assert!(
+        count < 300,
+        "process limit allowed the entire flood: {count}"
+    );
+}
+
+#[test]
+fn git_inspection_works_without_repository_execution_configuration() {
+    let result = bash(
+        "git -c core.hooksPath=/dev/null -c core.pager=cat \
+         -c credential.helper= -c diff.external= status --porcelain >/dev/null && \
+         git -c core.hooksPath=/dev/null -c core.pager=cat \
+         -c credential.helper= -c diff.external= diff --stat >/dev/null && \
+         if git config --get credential.helper >/dev/null 2>&1; then \
+           echo credential_config_visible; else echo git_config_hidden; fi",
+    );
+    assert!(
+        !result.is_error,
+        "safe Git inspection failed: {}",
+        result.content
+    );
+    assert!(result.content.contains("git_config_hidden"));
+    assert!(!result.content.contains("credential_config_visible"));
+}
+
+#[test]
+fn toolchain_mounts_are_read_only_and_exclude_user_credentials() {
+    let result = bash(
+        "cargo --version >/dev/null && \
+         test ! -e \"$HOME/.cargo/credentials\" && \
+         test ! -e \"$HOME/.cargo/credentials.toml\" && \
+         if touch \"$HOME/.cargo/bin/openclaudia-write-probe\" 2>/dev/null; then \
+           echo cache_writable; else echo toolchain_confined; fi",
+    );
+    assert!(
+        !result.is_error,
+        "read-only Cargo toolchain probe failed: {}",
+        result.content
+    );
+    assert!(result.content.contains("toolchain_confined"));
+    assert!(!result.content.contains("cache_writable"));
+}
+
+#[test]
+fn ambient_ipc_proxy_and_secret_shaped_environment_is_absent() {
+    struct EnvironmentCanaries;
+    impl Drop for EnvironmentCanaries {
+        fn drop(&mut self) {
+            // SAFETY: the required security test suite runs this integration
+            // binary with one test thread; these names are test-unique.
+            unsafe {
+                std::env::remove_var("SSH_OPENCLAUDIA_CANARY");
+                std::env::remove_var("DBUS_OPENCLAUDIA_CANARY");
+                std::env::remove_var("HTTPS_PROXY_OPENCLAUDIA_CANARY");
+                std::env::remove_var("OPENCLAUDIA_TEST_API_KEY");
+            }
+        }
+    }
+    // SAFETY: see the guard above.
+    unsafe {
+        std::env::set_var("SSH_OPENCLAUDIA_CANARY", "secret");
+        std::env::set_var("DBUS_OPENCLAUDIA_CANARY", "secret");
+        std::env::set_var("HTTPS_PROXY_OPENCLAUDIA_CANARY", "secret");
+        std::env::set_var("OPENCLAUDIA_TEST_API_KEY", "secret");
+    }
+    let _canaries = EnvironmentCanaries;
+    let result = bash(
+        "env | grep -E '^(SSH_OPENCLAUDIA_CANARY|DBUS_OPENCLAUDIA_CANARY|\
+         HTTPS_PROXY_OPENCLAUDIA_CANARY|OPENCLAUDIA_TEST_API_KEY)=' \
+         && echo env_leaked || echo env_confined",
+    );
+    assert!(
+        !result.is_error,
+        "environment probe failed: {}",
+        result.content
+    );
+    assert!(result.content.contains("env_confined"));
+    assert!(!result.content.contains("secret"));
+}
+
+#[test]
+fn address_space_and_open_file_limits_are_effective() {
+    let python = r#"
+memory_blocked = False
+try:
+    bytearray(5 * 1024 * 1024 * 1024)
+except (MemoryError, OverflowError):
+    memory_blocked = True
+files = []
+try:
+    while True:
+        files.append(open("/dev/null", "rb"))
+except OSError:
+    pass
+print("memory_blocked=" + str(memory_blocked).lower())
+print("open_files=" + str(len(files)))
+"#;
+    let result = bash(&format!(
+        "python3 -c {}",
+        shlex::try_quote(python).expect("quote Python")
+    ));
+    assert!(
+        !result.is_error,
+        "resource probe failed: {}",
+        result.content
+    );
+    assert!(result.content.contains("memory_blocked=true"));
+    let count = result
+        .content
+        .split("open_files=")
+        .nth(1)
+        .and_then(|tail| tail.lines().next())
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .expect("open-file count");
+    assert!(count <= 1024, "open-file cap was not enforced: {count}");
+}

--- a/tests/sandbox_platform_fail_closed_e2e.rs
+++ b/tests/sandbox_platform_fail_closed_e2e.rs
@@ -1,0 +1,20 @@
+//! Platforms without a production backend must report the limitation and
+//! reject agent execution instead of silently running on the host.
+
+#![cfg(any(target_os = "macos", windows))]
+#![allow(clippy::missing_panics_doc)]
+
+#[test]
+fn unsupported_production_backend_fails_closed_with_diagnostics() {
+    let diagnostics = openclaudia::tools::sandbox_diagnostics();
+    assert!(!diagnostics.healthy);
+    assert!(!diagnostics.explicit_host_opt_out);
+    assert_eq!(diagnostics.network, "denied");
+    assert_eq!(diagnostics.syscall_filter, "unavailable");
+    assert!(openclaudia::tools::sandbox_preflight().is_err());
+
+    #[cfg(target_os = "macos")]
+    assert_eq!(diagnostics.backend, "macos-unavailable");
+    #[cfg(windows)]
+    assert_eq!(diagnostics.backend, "windows-appcontainer");
+}

--- a/tests/session_filesystem_capabilities_e2e.rs
+++ b/tests/session_filesystem_capabilities_e2e.rs
@@ -1,0 +1,181 @@
+//! Adversarial coverage for per-session filesystem capabilities and
+//! descriptor-relative path resolution.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::unwrap_used)]
+
+use openclaudia::tools::{execute_tool, FunctionCall, SessionIdGuard, ToolCall};
+use serde_json::json;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn session_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn call(name: &str, arguments: serde_json::Value) -> openclaudia::tools::ToolResult {
+    execute_tool(&ToolCall {
+        id: format!("filesystem-capability-{name}"),
+        call_type: "function".to_string(),
+        function: FunctionCall {
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        },
+    })
+}
+
+#[cfg(unix)]
+#[test]
+fn private_session_temp_is_narrow_isolated_and_symlink_safe() {
+    let _serial = session_lock();
+    let session_a = SessionIdGuard::set("filesystem-private-temp-a");
+    let context_a = openclaudia::tools::security::current_context().expect("context A");
+    let a_file = context_a.private_temp_root().join("owned.txt");
+    std::fs::write(&a_file, "session-a-secret").expect("write A fixture");
+
+    let own_read = call("read_file", json!({ "path": a_file }));
+    assert!(
+        !own_read.is_error,
+        "session must read its own temp: {own_read:?}"
+    );
+    assert!(own_read.content.contains("session-a-secret"));
+
+    let sibling = tempfile::tempdir().expect("sibling OS temp");
+    let sibling_file = sibling.path().join("sibling.txt");
+    std::fs::write(&sibling_file, "sibling-secret").expect("write sibling");
+    let sibling_read = call("read_file", json!({ "path": sibling_file }));
+    assert!(sibling_read.is_error, "shared OS temp must not be granted");
+    assert!(!sibling_read.content.contains("sibling-secret"));
+
+    let link = context_a.private_temp_root().join("escape-link");
+    std::os::unix::fs::symlink(&sibling_file, &link).expect("plant symlink");
+    let link_read = call("read_file", json!({ "path": link }));
+    assert!(link_read.is_error, "temp symlink escape must be denied");
+    assert!(!link_read.content.contains("sibling-secret"));
+
+    drop(session_a);
+    let _session_b = SessionIdGuard::set("filesystem-private-temp-b");
+    let context_b = openclaudia::tools::security::current_context().expect("context B");
+    assert_ne!(
+        context_a.private_temp_root(),
+        context_b.private_temp_root(),
+        "sessions must not share temporary roots"
+    );
+    let cross_read = call("read_file", json!({ "path": a_file }));
+    assert!(
+        cross_read.is_error,
+        "session B must not read session A temp"
+    );
+    assert!(!cross_read.content.contains("session-a-secret"));
+}
+
+#[cfg(target_os = "linux")]
+fn rename_exchange(first: &std::path::Path, second: &std::path::Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let first = CString::new(first.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let second = CString::new(second.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    // SAFETY: both path buffers are stable and NUL-terminated for the syscall.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            first.as_ptr(),
+            libc::AT_FDCWD,
+            second.as_ptr(),
+            libc::RENAME_EXCHANGE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn intermediate_directory_symlink_swap_cannot_escape_reads_or_writes() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct Swapper {
+        stop: Arc<AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
+    impl Drop for Swapper {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    let _serial = session_lock();
+    let _session = SessionIdGuard::set("filesystem-openat2-intermediate-race");
+    let project_fixture = tempfile::tempdir_in(".").expect("project fixture");
+    let outside = tempfile::tempdir().expect("outside fixture");
+
+    let live = project_fixture.path().join("live");
+    let alternate = project_fixture.path().join("alternate");
+    std::fs::create_dir(&live).expect("safe directory");
+    std::fs::write(live.join("secret.txt"), "INSIDE").expect("safe content");
+    std::fs::write(outside.path().join("secret.txt"), "OUTSIDE-SENTINEL").expect("outside content");
+    std::os::unix::fs::symlink(outside.path(), &alternate).expect("outside symlink");
+    // Prove the kernel/filesystem supports the atomic primitive before the
+    // adversarial loop, restoring the initial arrangement afterward.
+    rename_exchange(&live, &alternate).expect("first exchange");
+    rename_exchange(&live, &alternate).expect("restore exchange");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let swap_stop = Arc::clone(&stop);
+    let swap_live = live.clone();
+    let swap_alternate = alternate;
+    let handle = std::thread::spawn(move || {
+        while !swap_stop.load(Ordering::Relaxed) {
+            if rename_exchange(&swap_live, &swap_alternate).is_err() {
+                break;
+            }
+        }
+    });
+    let swapper = Swapper {
+        stop,
+        handle: Some(handle),
+    };
+
+    for index in 0..500 {
+        let read = call("read_file", json!({ "path": live.join("secret.txt") }));
+        assert!(
+            !read.content.contains("OUTSIDE-SENTINEL"),
+            "confined read returned outside content: {read:?}"
+        );
+
+        let write_name = format!("race-write-{index}.txt");
+        let write = call(
+            "write_file",
+            json!({
+                "path": live.join(&write_name),
+                "content": "confined"
+            }),
+        );
+        let _ = write;
+        assert!(
+            !outside.path().join(&write_name).exists(),
+            "write escaped through swapped intermediate directory"
+        );
+    }
+
+    drop(swapper);
+    assert_eq!(
+        std::fs::read_to_string(outside.path().join("secret.txt")).expect("outside sentinel"),
+        "OUTSIDE-SENTINEL"
+    );
+}

--- a/tests/skill_dispatch_validation_e2e.rs
+++ b/tests/skill_dispatch_validation_e2e.rs
@@ -36,6 +36,7 @@ fn run_in_tempdir<R>(f: impl FnOnce() -> R) -> R {
 
 fn dispatch_skill(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/subprocess_boundary_e2e.rs
+++ b/tests/subprocess_boundary_e2e.rs
@@ -1,0 +1,79 @@
+//! Structural guard for agent-reachable subprocess creation.
+//!
+//! Runtime escape tests prove the launcher works. This test complements them
+//! by making a newly introduced direct process constructor in an agent module
+//! fail review even before an escape payload is written.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::missing_panics_doc)]
+
+fn production_source(path: &str) -> String {
+    let source = std::fs::read_to_string(path).expect("source file");
+    source
+        .split("#[cfg(test)]\nmod tests")
+        .next()
+        .unwrap_or(&source)
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with("//") && !trimmed.starts_with("///") && !trimmed.starts_with("//!")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn agent_modules_do_not_construct_host_processes_directly() {
+    let guarded = [
+        "src/acp.rs",
+        "src/guardrails.rs",
+        "src/mcp.rs",
+        "src/subagent.rs",
+        "src/tools/file/read.rs",
+        "src/tools/lsp.rs",
+        "src/tools/worktree.rs",
+        "src/vdd/static_analysis.rs",
+    ];
+    for path in guarded {
+        let source = production_source(path);
+        assert!(
+            !source.contains("Command::new(")
+                && !source.contains("std::process::Command::new(")
+                && !source.contains("tokio::process::Command::new("),
+            "{path} introduced a direct subprocess constructor; select a named SandboxProfile \
+             and use the common sandbox launcher"
+        );
+    }
+}
+
+#[test]
+fn hook_process_construction_remains_followed_by_enforced_sandboxing() {
+    let source = production_source("src/hooks/mod.rs");
+    let direct_constructors = source
+        .lines()
+        .filter(|line| line.contains("Command::new("))
+        .count();
+    assert_eq!(
+        direct_constructors, 2,
+        "hook command parsing has exactly two constructors (direct argv and explicit shell); \
+         any new constructor needs a sandbox-boundary review"
+    );
+    assert!(source.contains("sandboxed_hook_command("));
+    assert!(source.contains("TRUST_UNSANDBOXED_HOOKS_ENV"));
+    assert!(source.contains("sandbox_mode == SandboxMode::FullSandbox"));
+}
+
+#[test]
+fn unsandboxed_runner_is_test_only_and_agent_git_uses_named_profiles() {
+    let command = std::fs::read_to_string("src/tools/command.rs").expect("command source");
+    let marker = "#[cfg(test)]\npub fn run_with_timeout(";
+    assert!(
+        command.contains(marker),
+        "the host subprocess helper must remain unavailable in production builds"
+    );
+    for path in ["src/tools/worktree.rs", "src/subagent.rs"] {
+        let source = production_source(path);
+        assert!(source.contains("SandboxProfile::GitWorktree"));
+        assert!(!source.contains("run_with_timeout("));
+    }
+}

--- a/tests/task_dispatch_validation_e2e.rs
+++ b/tests/task_dispatch_validation_e2e.rs
@@ -20,6 +20,7 @@ const NO_SESSION_MARKER: &str = "Task management not available (no session)";
 
 fn dispatch_without_session(name: &str, args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -35,6 +36,7 @@ fn dispatch_with_session(
     tm: &mut TaskManager,
 ) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: Some(tm),

--- a/tests/todo_write_dispatch_validation_e2e.rs
+++ b/tests/todo_write_dispatch_validation_e2e.rs
@@ -27,6 +27,7 @@ fn todo_lock() -> MutexGuard<'static, ()> {
 
 fn dispatch(name: &str, args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/tool_context_dispatch_e2e.rs
+++ b/tests/tool_context_dispatch_e2e.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 #[test]
 fn tool_context_struct_literal_with_all_none_fields() {
     let ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -40,6 +41,7 @@ const fn accept_mut_ref(c: &mut ToolContext<'_>) {
 #[test]
 fn tool_context_can_be_taken_by_mut_reference_for_dispatch() {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -52,6 +54,7 @@ fn tool_context_can_be_taken_by_mut_reference_for_dispatch() {
 fn tool_context_field_assignment_via_struct_literal_works() {
     // PINS SHAPE: 3 documented fields, all Option types.
     let ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -70,6 +73,7 @@ fn tool_context_field_assignment_via_struct_literal_works() {
 fn dispatch_unknown_tool_returns_none() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -83,6 +87,7 @@ fn dispatch_unknown_tool_returns_none() {
 fn dispatch_empty_string_tool_name_returns_none() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -96,6 +101,7 @@ fn dispatch_empty_string_tool_name_returns_none() {
 fn dispatch_whitespace_only_tool_name_returns_none() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -113,6 +119,7 @@ fn dispatch_whitespace_only_tool_name_returns_none() {
 fn get_returns_some_iff_dispatch_returns_some_for_same_name() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -156,6 +163,7 @@ fn registry_get_for_known_tool_returns_some_handler() {
 fn dispatch_tool_search_returns_some_tuple() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -180,6 +188,7 @@ fn dispatch_tool_search_returns_some_tuple() {
 fn dispatch_unknown_tool_with_arbitrary_args_still_returns_none() {
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -198,6 +207,7 @@ fn dispatch_known_tool_with_empty_args_invokes_handler() {
     // handler decides what to do with empty.
     let reg = registry();
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/tool_search_dispatch_e2e.rs
+++ b/tests/tool_search_dispatch_e2e.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 
 fn dispatch_tool_search(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/tools_security_e2e.rs
+++ b/tests/tools_security_e2e.rs
@@ -354,7 +354,7 @@ fn session_id_guards_are_stack_scoped_and_restore_on_drop() {
     // drops still sees the same file as "not read in this session"
     // because each `SessionIdGuard::set` overwrites the slot.
 
-    let dir = tempdir().expect("tempdir");
+    let dir = tempfile::tempdir_in(".").expect("tempdir");
     let path = dir.path().join("scoped.txt");
     std::fs::write(&path, "v1").expect("write");
 

--- a/tests/web_tool_url_validation_e2e.rs
+++ b/tests/web_tool_url_validation_e2e.rs
@@ -26,6 +26,7 @@ fn args_with(entries: &[(&str, Value)]) -> HashMap<String, Value> {
 
 fn execute_web_fetch(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -38,6 +39,7 @@ fn execute_web_fetch(args: &HashMap<String, Value>) -> (String, bool) {
 #[cfg(feature = "browser")]
 fn execute_web_browser(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/worktree_dispatch_validation_e2e.rs
+++ b/tests/worktree_dispatch_validation_e2e.rs
@@ -18,6 +18,7 @@ use tempfile::TempDir;
 
 fn dispatch(name: &str, args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,

--- a/tests/write_file_dispatch_validation_e2e.rs
+++ b/tests/write_file_dispatch_validation_e2e.rs
@@ -16,17 +16,11 @@ use openclaudia::tools::registry::{registry, ToolContext};
 use openclaudia::tools::SessionIdGuard;
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
-
-fn cwd_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
+use std::sync::{Arc, Mutex};
 
 fn dispatch_write(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -38,6 +32,7 @@ fn dispatch_write(args: &HashMap<String, Value>) -> (String, bool) {
 
 fn dispatch_read(args: &HashMap<String, Value>) -> (String, bool) {
     let mut ctx = ToolContext {
+        security: openclaudia::tools::security::current_context(),
         memory_db: None,
         app_config: None,
         task_mgr: None,
@@ -127,26 +122,23 @@ fn path_with_parent_dir_traversal_rejected_pre_write() {
 }
 
 #[test]
-fn relative_path_is_accepted_and_resolved_to_cwd_relative() {
+fn relative_path_is_accepted_and_resolved_to_session_root() {
     // AUTHORING DISCOVERY: relative paths are accepted —
-    // resolve_path joins them to std::env::current_dir().
-    // This is documented behavior (not a security hole).
+    // secure resolution joins them to the immutable session root.
     // The dispatch must NOT reject for relative-ness alone.
-    let _l = cwd_lock();
-    let dir = tempfile::TempDir::new().expect("tempdir");
-    let prev_cwd = std::env::current_dir().expect("cwd");
-    std::env::set_current_dir(dir.path()).expect("cd");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
+    let path = dir.path().join("new_relative_file_xyz.txt");
 
     let args = args_with(&[
-        ("path", json!("new_relative_file_xyz.txt")),
+        ("path", json!(path.to_string_lossy())),
         ("content", json!("body")),
     ]);
     let (msg, is_err) = dispatch_write(&args);
-    let _ = std::env::set_current_dir(&prev_cwd);
     assert!(
         !is_err,
-        "relative path MUST be accepted (resolved to cwd); got error {msg:?}"
+        "relative path MUST be accepted (resolved to session root); got error {msg:?}"
     );
+    assert_eq!(std::fs::read_to_string(path).expect("read back"), "body");
 }
 
 #[test]
@@ -156,7 +148,7 @@ fn write_file_records_diff_observation_when_session_ledger_is_active() {
     let _ledger_guard =
         openclaudia::ledger::install_active_ledger_for_session("writeledger", Arc::clone(&ledger));
 
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("ledger_write.txt");
     let args = args_with(&[
         ("path", json!(path.to_str().unwrap())),
@@ -193,7 +185,7 @@ fn write_file_records_diff_observation_when_session_ledger_is_active() {
 fn missing_content_arg_on_new_file_errors() {
     // Use a tempdir path so the file path validates successfully
     // and we reach the content check.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("new_unique_file_marker.txt");
     let args = args_with(&[("path", json!(path.to_str().unwrap()))]);
     let (msg, is_err) = dispatch_write(&args);
@@ -206,7 +198,7 @@ fn missing_content_arg_on_new_file_errors() {
 
 #[test]
 fn content_arg_as_number_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("test.txt");
     let args = args_with(&[
         ("path", json!(path.to_str().unwrap())),
@@ -222,7 +214,7 @@ fn content_arg_as_number_returns_validation_error() {
 
 #[test]
 fn content_arg_as_array_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("test.txt");
     let args = args_with(&[
         ("path", json!(path.to_str().unwrap())),
@@ -235,7 +227,7 @@ fn content_arg_as_array_returns_validation_error() {
 
 #[test]
 fn content_arg_as_null_returns_validation_error() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("test.txt");
     let args = args_with(&[
         ("path", json!(path.to_str().unwrap())),
@@ -294,7 +286,7 @@ fn overwrite_existing_file_without_prior_read_errors() {
     // PINS #968: an existing file that has NOT been read via
     // read_file in this session cannot be overwritten — model
     // would be hallucinating prior content.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("existing_unique_marker.txt");
     // Pre-create file (existing) without going through read_file.
     std::fs::write(&path, "original content").expect("create");
@@ -325,7 +317,7 @@ fn overwrite_existing_file_without_prior_read_errors() {
 #[test]
 fn failed_read_does_not_satisfy_overwrite_gate() {
     let _session_guard = SessionIdGuard::set("failed-read-overwrite-gate");
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("empty.png");
     std::fs::write(&path, "").expect("create empty image");
     let path_str = path.to_str().expect("utf8 path");
@@ -359,7 +351,7 @@ fn failed_read_does_not_satisfy_overwrite_gate() {
 #[test]
 fn empty_string_content_is_accepted_for_new_file() {
     // Empty content string is valid — creates empty file.
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("empty_new.txt");
     let args = args_with(&[
         ("path", json!(path.to_str().unwrap())),
@@ -373,7 +365,7 @@ fn empty_string_content_is_accepted_for_new_file() {
 
 #[test]
 fn unicode_content_writes_byte_exact() {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    let dir = tempfile::TempDir::new_in(".").expect("tempdir");
     let path = dir.path().join("unicode.txt");
     let content = "日本語コンテンツ 🎉";
     let args = args_with(&[


### PR DESCRIPTION
## Summary

- Replace ambient, process-wide tool authority with per-session execution contexts and capability-scoped dispatch.
- Harden file operations against traversal, symlink, and time-of-check/time-of-use escape paths.
- Add Linux subprocess isolation and route agent-controlled process launches through the guarded command boundary, failing closed where equivalent isolation is unavailable.
- Add adversarial sandbox coverage, CI enforcement, a threat model, a subprocess inventory, and a follow-up issue ledger.
- Refresh every compatible Rust dependency in the root and fuzz lockfiles, including `base64` 0.23 and `ed25519-dalek` 3.

## Security impact

The previous boundary combined shared ambient authority, path checks performed separately from file access, and subprocess paths that could bypass a single sandbox policy. This change makes authority explicit per execution context, performs sensitive filesystem access through hardened primitives, and centralizes subprocess enforcement.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --no-fail-fast --quiet -- --test-threads=1`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `cargo check --target x86_64-pc-windows-gnu --no-default-features`
- `cargo audit --file Cargo.lock`
- `cargo audit --file fuzz/Cargo.lock`
- `git diff --check`

Both advisory scans report no known vulnerabilities. They retain transitive maintenance warnings for `bincode` 1.x and `yaml-rust` 0.4.

## Dependency constraints

- `rusqlite` remains at 0.38 because the latest published `crosslink` release requires that SQLite native-link version; 0.40 cannot coexist in the graph.
- `generic-array` 0.14.7 is exact-pinned by `crypto-common` 0.1.7.
- `matchit` 0.8.4 is exact-pinned by Axum 0.8.9.